### PR TITLE
BUGFIX: Fix support for `Discriminator` attribute on optional properties

### DIFF
--- a/src/Attributes/Discriminator.php
+++ b/src/Attributes/Discriminator.php
@@ -6,7 +6,7 @@ namespace Wwwision\Types\Attributes;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PARAMETER)]
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 final class Discriminator
 {
     /**

--- a/src/Schema/OptionalSchema.php
+++ b/src/Schema/OptionalSchema.php
@@ -4,11 +4,22 @@ declare(strict_types=1);
 
 namespace Wwwision\Types\Schema;
 
+use Wwwision\Types\Attributes\Discriminator;
+use Wwwision\Types\Exception\InvalidSchemaException;
+
 final class OptionalSchema implements Schema
 {
     public function __construct(
         public readonly Schema $wrapped,
     ) {}
+
+    public function withDiscriminator(Discriminator $discriminator): self
+    {
+        if (!$this->wrapped instanceof OneOfSchema && !$this->wrapped instanceof InterfaceSchema) {
+            throw new InvalidSchemaException(sprintf('The schema for type "%s" is of type %s which is not one of the supported schema types %s', $this->getName(), $this->wrapped::class, implode(', ', [OneOfSchema::class, InterfaceSchema::class])));
+        }
+        return new self($this->wrapped->withDiscriminator($discriminator));
+    }
 
     public function getType(): string
     {

--- a/src/Schema/ShapeSchema.php
+++ b/src/Schema/ShapeSchema.php
@@ -157,11 +157,15 @@ final class ShapeSchema implements Schema
         if (!array_key_exists($propertyName, $this->propertyDiscriminators)) {
             return $propertySchema;
         }
-        $supportedPropertySchemas = [OneOfSchema::class, InterfaceSchema::class];
+        $supportedPropertySchemas = [OneOfSchema::class, InterfaceSchema::class, OptionalSchema::class];
         if (!in_array($propertySchema::class, $supportedPropertySchemas, true)) {
             throw new InvalidSchemaException(sprintf('Class "%s" has a %s attribute for property "%s" but the corresponding property schema is of type %s which is not one of the supported schema types %s', $this->getName(), Discriminator::class, $propertyName, get_debug_type($propertySchema), implode(', ', $supportedPropertySchemas)));
         }
-        /** @var OneOfSchema|InterfaceSchema $propertySchema */
-        return $propertySchema->withDiscriminator($this->propertyDiscriminators[$propertyName]);
+        /** @var OneOfSchema|InterfaceSchema|OptionalSchema $propertySchema */
+        try {
+            return $propertySchema->withDiscriminator($this->propertyDiscriminators[$propertyName]);
+        } catch (InvalidSchemaException $e) {
+            throw new InvalidSchemaException(sprintf('Class "%s" incorrectly has a %s attribute for property "%s": %s', $this->getName(), Discriminator::class, $propertyName, $e->getMessage()), 1734543079, $e);
+        }
     }
 }


### PR DESCRIPTION
Previously the following wasn't possible:

```php
final class SomeClass
{
    public function __construct(
        #[Discriminator(propertyName: 'type'])]
        public readonly SomeInterface|null $property = null,
    ) {}
}
```

because the property was optional.
This is now allowed.