### PR TITLE
FEATURE: Normalizer

### DIFF
--- a/src/Normalizer/Normalizer.php
+++ b/src/Normalizer/Normalizer.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\Types\Normalizer;
+
+use BackedEnum;
+use JsonException;
+use ReflectionAttribute;
+use ReflectionClass;
+use ReflectionNamedType;
+use RuntimeException;
+use Traversable;
+use UnitEnum;
+use Wwwision\Types\Attributes\Discriminator;
+use Wwwision\Types\Attributes\ListBased;
+use Wwwision\Types\Attributes\TypeBased;
+
+final class Normalizer
+{
+    public function __construct(
+        private bool $includeRootLevelTypeDiscrimination = true,
+    ) {}
+
+    public function normalize(object $object): mixed
+    {
+        $reflectionClass = new ReflectionClass($object);
+        $result = $this->normalizeInternal($object, $reflectionClass);
+        if ($this->includeRootLevelTypeDiscrimination && ($classDiscriminator = self::getClassDiscriminator($reflectionClass)) !== null) {
+            $result = self::discriminateValue($result, $object::class, $classDiscriminator);
+        }
+        return $result;
+    }
+
+    /**
+     * @template T of object
+     * @param T $object
+     * @param ReflectionClass<T> $reflectionClass
+     */
+    private function normalizeInternal(object $object, ReflectionClass $reflectionClass): mixed
+    {
+        if ($object instanceof BackedEnum) {
+            return $object->value;
+        }
+        if ($object instanceof UnitEnum) {
+            return $object->name;
+        }
+        if ($object instanceof Traversable) {
+            $result = $this->normalizeIterable($object, $reflectionClass);
+        } elseif (self::isTypeBased($reflectionClass)) {
+            $properties = get_object_vars($object);
+            $result = $properties[array_key_first($properties)];
+        } else {
+            $result = [];
+            foreach (get_object_vars($object) as $propertyName => $propertyValue) {
+                if (is_iterable($propertyValue)) {
+                    $normalizedPropertyValue = is_object($propertyValue) ? $this->normalizeIterable($propertyValue, new ReflectionClass($propertyValue)) : $propertyValue;
+                } elseif (is_object($propertyValue)) {
+                    $normalizedPropertyValue = $this->normalizeInternal($propertyValue, new ReflectionClass($propertyValue));
+                } else {
+                    $normalizedPropertyValue = $propertyValue;
+                }
+                if (is_object($propertyValue) && ($propertyDiscriminator = self::getPropertyDiscriminator($reflectionClass, $propertyName)) !== null) {
+                    $normalizedPropertyValue = self::discriminateValue($normalizedPropertyValue, $propertyValue::class, $propertyDiscriminator);
+                }
+                $result[$propertyName] = $normalizedPropertyValue;
+            }
+        }
+        return $result;
+    }
+
+    public function toJson(object $object): string
+    {
+        try {
+            return json_encode($this->normalize($object), JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+            // @codeCoverageIgnoreStart
+        } catch (JsonException $e) {
+            throw new RuntimeException(sprintf('Failed to JSON encode object of type "%s": %s', get_debug_type($object), $e->getMessage()), 1734598009, $e);
+        }
+        // @codeCoverageIgnoreEnd
+    }
+
+    /**
+     * @template T of object
+     * @param iterable<mixed> $iterable
+     * @param ReflectionClass<T> $reflectionClass
+     * @return array<mixed>
+     */
+    private function normalizeIterable(iterable $iterable, ReflectionClass $reflectionClass): array
+    {
+        $itemDiscriminator = null;
+        /** @var ReflectionAttribute<ListBased>|null $listBasedReflectionAttribute */
+        $listBasedReflectionAttribute = $reflectionClass->getAttributes(ListBased::class, ReflectionAttribute::IS_INSTANCEOF)[0] ?? null;
+        if ($listBasedReflectionAttribute !== null) {
+            $itemDiscriminator = self::getClassDiscriminator(new ReflectionClass($listBasedReflectionAttribute->newInstance()->itemClassName));
+        }
+        $result = [];
+        foreach ($iterable as $key => $item) {
+            if (is_object($item)) {
+                $normalizedItem = $this->normalizeInternal($item, new ReflectionClass($item));
+                if ($itemDiscriminator !== null) {
+                    $normalizedItem = self::discriminateValue($normalizedItem, get_class($item), $itemDiscriminator);
+                }
+            } else {
+                $normalizedItem = $item;
+            }
+            $result[$key] = $normalizedItem;
+        }
+        return $result;
+    }
+
+    /**
+     * @param ReflectionClass<object> $reflectionClass
+     */
+    private static function isTypeBased(ReflectionClass $reflectionClass): bool
+    {
+        return $reflectionClass->getAttributes(TypeBased::class, \ReflectionAttribute::IS_INSTANCEOF) !== [];
+    }
+
+    /**
+     * @param ReflectionClass<object> $reflectionClass
+     */
+    private static function getClassDiscriminator(ReflectionClass $reflectionClass): Discriminator|null
+    {
+        $reflectionInterfaces = $reflectionClass->isInterface() ? [$reflectionClass] : $reflectionClass->getInterfaces();
+        foreach ($reflectionInterfaces as $reflectionInterface) {
+            /** @var array<ReflectionAttribute<Discriminator>> $discriminatorAttributes */
+            $discriminatorAttributes = $reflectionInterface->getAttributes(Discriminator::class);
+            if ($discriminatorAttributes === []) {
+                continue;
+            }
+            return $discriminatorAttributes[0]->newInstance();
+        }
+        if ($reflectionClass->isInterface()) {
+            return new Discriminator('__type');
+        }
+        return null;
+    }
+
+    /**
+     * @param ReflectionClass<object> $reflectionClass
+     */
+    private static function getPropertyDiscriminator(ReflectionClass $reflectionClass, string $propertyName): Discriminator|null
+    {
+        $propertyReflection = $reflectionClass->getProperty($propertyName);
+        /** @var array<ReflectionAttribute<Discriminator>> $discriminatorAttributes */
+        $discriminatorAttributes = $propertyReflection->getAttributes(Discriminator::class);
+        if ($discriminatorAttributes === []) {
+            $propertyType = $propertyReflection->getType();
+            if ($propertyType instanceof ReflectionNamedType && interface_exists($propertyType->getName())) {
+                return self::getClassDiscriminator(new ReflectionClass($propertyType->getName()));
+            }
+            return null;
+        }
+        return $discriminatorAttributes[0]->newInstance();
+    }
+
+    /**
+     * @param class-string $valueClassName
+     */
+    private static function discriminateValue(mixed $value, string $valueClassName, Discriminator $discriminator): mixed
+    {
+        if (!is_array($value)) {
+            $value = ['__value' => $value];
+        }
+        return [$discriminator->propertyName => self::getDiscriminatorValueForClassName($valueClassName, $discriminator->mapping), ...$value];
+    }
+
+    /**
+     * @param class-string $className
+     * @param array<non-empty-string, class-string>|null $mapping
+     */
+    private static function getDiscriminatorValueForClassName(string $className, array|null $mapping): string|null
+    {
+        if ($mapping === null) {
+            return $className;
+        }
+        foreach ($mapping as $mappingValue => $mappingClassName) {
+            if ($className === $mappingClassName) {
+                return $mappingValue;
+            }
+        }
+        return null;
+    }
+
+}

--- a/tests/PHPUnit/NormalizerTest.php
+++ b/tests/PHPUnit/NormalizerTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\Types\Tests\PHPUnit;
+
+use Generator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Wwwision\Types\Attributes\Description;
+use Wwwision\Types\Attributes\Discriminator;
+use Wwwision\Types\Attributes\FloatBased;
+use Wwwision\Types\Attributes\IntegerBased;
+use Wwwision\Types\Attributes\ListBased;
+use Wwwision\Types\Attributes\StringBased;
+use Wwwision\Types\Exception\CoerceException;
+use Wwwision\Types\Exception\Issues\Custom;
+use Wwwision\Types\Exception\Issues\InvalidEnumValue;
+use Wwwision\Types\Exception\Issues\InvalidString;
+use Wwwision\Types\Exception\Issues\InvalidType;
+use Wwwision\Types\Exception\Issues\IssueCode;
+use Wwwision\Types\Exception\Issues\Issues;
+use Wwwision\Types\Exception\Issues\TooBig;
+use Wwwision\Types\Exception\Issues\TooSmall;
+use Wwwision\Types\Exception\Issues\UnrecognizedKeys;
+use Wwwision\Types\Normalizer\Normalizer;
+use Wwwision\Types\Parser;
+use Wwwision\Types\Schema\ArraySchema;
+use Wwwision\Types\Schema\EnumCaseSchema;
+use Wwwision\Types\Schema\EnumSchema;
+use Wwwision\Types\Schema\FloatSchema;
+use Wwwision\Types\Schema\IntegerSchema;
+use Wwwision\Types\Schema\InterfaceSchema;
+use Wwwision\Types\Schema\ListSchema;
+use Wwwision\Types\Schema\LiteralBooleanSchema;
+use Wwwision\Types\Schema\LiteralFloatSchema;
+use Wwwision\Types\Schema\LiteralIntegerSchema;
+use Wwwision\Types\Schema\LiteralStringSchema;
+use Wwwision\Types\Schema\OneOfSchema;
+use Wwwision\Types\Schema\OptionalSchema;
+use Wwwision\Types\Schema\ShapeSchema;
+use Wwwision\Types\Schema\StringSchema;
+use Wwwision\Types\Schema\StringTypeFormat;
+use Wwwision\Types\Tests\Fixture;
+
+use function Wwwision\Types\instantiate;
+
+require_once __DIR__ . '/../Fixture/Fixture.php';
+
+#[CoversClass(ArraySchema::class)]
+#[CoversClass(CoerceException::class)]
+#[CoversClass(Custom::class)]
+#[CoversClass(Description::class)]
+#[CoversClass(Discriminator::class)]
+#[CoversClass(EnumCaseSchema::class)]
+#[CoversClass(EnumSchema::class)]
+#[CoversClass(FloatBased::class)]
+#[CoversClass(FloatSchema::class)]
+#[CoversClass(IntegerBased::class)]
+#[CoversClass(IntegerSchema::class)]
+#[CoversClass(InterfaceSchema::class)]
+#[CoversClass(InvalidEnumValue::class)]
+#[CoversClass(InvalidString::class)]
+#[CoversClass(InvalidType::class)]
+#[CoversClass(IssueCode::class)]
+#[CoversClass(Issues::class)]
+#[CoversClass(ListBased::class)]
+#[CoversClass(ListSchema::class)]
+#[CoversClass(LiteralBooleanSchema::class)]
+#[CoversClass(LiteralFloatSchema::class)]
+#[CoversClass(LiteralIntegerSchema::class)]
+#[CoversClass(LiteralStringSchema::class)]
+#[CoversClass(Normalizer::class)]
+#[CoversClass(OneOfSchema::class)]
+#[CoversClass(OptionalSchema::class)]
+#[CoversClass(Parser::class)]
+#[CoversClass(ShapeSchema::class)]
+#[CoversClass(StringBased::class)]
+#[CoversClass(StringSchema::class)]
+#[CoversClass(StringTypeFormat::class)]
+#[CoversClass(TooBig::class)]
+#[CoversClass(TooSmall::class)]
+#[CoversClass(UnrecognizedKeys::class)]
+#[CoversFunction('Wwwision\\Types\\instantiate')]
+final class NormalizerTest extends TestCase
+{
+    public static function normalize_dataProvider(): Generator
+    {
+        yield 'string-based' => ['className' => Fixture\GivenName::class, 'input' => 'John'];
+        yield 'string-based with type discrimination' => ['className' => Fixture\InterfaceWithDiscriminator::class, 'input' => ['t' => 'implementationA', '__value' => 'Foo']];
+        yield 'list-based' => ['className' => Fixture\GivenNames::class, 'input' => ['Jane', 'John', 'Hans']];
+        yield 'list of interfaces' => ['className' => Fixture\InterfaceList::class, 'input' => [['__type' => Fixture\ItemA::class, '__value' => 'A'], ['__type' => Fixture\ItemB::class, 'value' => 'B', 'givenName' => 'Jane']]];
+        yield 'unbacked enum' => ['className' => Fixture\Title::class, 'input' => 'MRS'];
+        yield 'int-backed enum' => ['className' => Fixture\Number::class, 'input' => 3];
+        yield 'string-backed enum' => ['className' => Fixture\RomanNumber::class, 'input' => '2'];
+        yield 'shape' => ['className' => Fixture\FullName::class, 'input' => ['givenName' => 'Jane', 'familyName' => 'Doe']];
+        yield 'shape with array property' => ['className' => Fixture\ShapeWithArray::class, 'input' => ['givenName' => 'John', 'someArray' => ['some', 'array', 'values']]];
+        yield 'shape with list-based property' => ['className' => Fixture\ShapeWithListBasedProperty::class, 'input' => ['givenNames' => ['John', 'Jane'], 'someString' => 'arbitrary string']];
+        yield 'shape with union type and discriminator' => ['className' => Fixture\ShapeWithUnionTypeAndDiscriminator::class, 'input' => ['givenOrFamilyName' => ['type' => 'given', '__value' => 'Jane']]];
+        yield 'shape with discriminated interface property' => ['className' => Fixture\ShapeWithDiscriminatedInterfaceProperty::class, 'input' => ['property' => ['t' => 'implementationA', '__value' => 'Foo']]];
+        yield 'shape with interface property and discriminator' => ['className' => Fixture\ShapeWithInterfacePropertyAndDiscriminator::class, 'input' => ['property' => ['type' => 'a', '__value' => 'Bar']]];
+        yield 'shape with type-discriminated properties' => ['className' => Fixture\ShapeWithTypeDiscriminatedProperties::class, 'input' => ['interfaceList' => [['__type' => Fixture\ItemA::class, '__value' => 'A'], ['__type' => Fixture\ItemB::class, 'value' => 'B', 'givenName' => 'Jane']], 'interfaceWithCustomDiscriminator' => ['customT' => 'A', '__value' => 'Foo'], 'interfaceWithDefaultDiscriminator' => ['t' => 'implementationA', '__value' => 'Bar'], 'stringArray' => ['foo', 'bar'], 'stringIterator' => ['first' => 'baz', 'second' => 'foos']]];
+    }
+
+    /**
+     * @param class-string $className
+     */
+    #[DataProvider('normalize_dataProvider')]
+    public function test_normalize(string $className, mixed $input): void
+    {
+        $instance = instantiate($className, $input);
+        $actualResult = (new Normalizer())->normalize($instance);
+        self::assertSame($input, $actualResult);
+    }
+
+    /**
+     * @param class-string $className
+     */
+    #[DataProvider('normalize_dataProvider')]
+    public function test_toJson(string $className, mixed $input): void
+    {
+        $instance = instantiate($className, $input);
+        $expectedResult = json_encode($input, JSON_THROW_ON_ERROR);
+        $actualResult = (new Normalizer())->toJson($instance);
+        self::assertSame($expectedResult, $actualResult);
+    }
+
+    public function test_normalize_includes_type_discrimination_for_root_item_by_default(): void
+    {
+        $instance = instantiate(Fixture\ImplementationAOfInterfaceWithDiscriminator::class, 'Foo');
+        $actualResult = (new Normalizer())->normalize($instance);
+        self::assertSame(['t' => 'implementationA', '__value' => 'Foo'], $actualResult);
+    }
+
+    public function test_normalize_does_not_includes_type_discrimination_for_root_item_if_is_not_a_discriminated_value(): void
+    {
+        $instance = instantiate(Fixture\GivenName::class, 'Jane');
+        $actualResult = (new Normalizer())->normalize($instance);
+        self::assertSame('Jane', $actualResult);
+    }
+
+    public function test_normalize_does_not_include_type_discrimination_for_root_item_if_disabled(): void
+    {
+        $instance = instantiate(Fixture\ImplementationAOfInterfaceWithDiscriminator::class, 'Foo');
+        $actualResult = (new Normalizer(includeRootLevelTypeDiscrimination: false))->normalize($instance);
+        self::assertSame('Foo', $actualResult);
+    }
+
+    public function test_discriminator_is_null_if_instance_does_not_match_any_mapping_value(): void
+    {
+        $class = new class implements Fixture\InterfaceWithDiscriminator {};
+        $instance = new $class();
+        $actualResult = (new Normalizer())->normalize($instance);
+        self::assertSame(['t' => null], $actualResult);
+    }
+
+}

--- a/tests/PHPUnit/ReadmeCodeBlockTest.php
+++ b/tests/PHPUnit/ReadmeCodeBlockTest.php
@@ -50,19 +50,20 @@ final class ReadmeCodeBlockTest extends TestCase
         self::$previousNamespace = $namespace;
         $namespacedCode = <<<CODE
             namespace $namespace {
-                use Countable;
-                use Closure;
-                use JsonSerializable;
-                use IteratorAggregate;
                 use ArrayIterator;
+                use Closure;
+                use Countable;
+                use IteratorAggregate;
+                use JsonSerializable;
                 use Traversable;
                 use Wwwision\Types\Attributes\Description;
                 use Wwwision\Types\Attributes\Discriminator;
-                use Wwwision\Types\Attributes\IntegerBased;
                 use Wwwision\Types\Attributes\FloatBased;
+                use Wwwision\Types\Attributes\IntegerBased;
                 use Wwwision\Types\Attributes\ListBased;
                 use Wwwision\Types\Attributes\StringBased;
                 use Wwwision\Types\Exception\CoerceException;
+                use Wwwision\Types\Normalizer\Normalizer;
                 use Wwwision\Types\Parser;
                 use Wwwision\Types\Schema\StringTypeFormat;
                 use function Wwwision\Types\instantiate;


### PR DESCRIPTION
Adds a dedicated `Normalizer` that can be used to convert arbitrary objects to simple types and/or JSON:

```php
#[StringBased]
final class Name {
    private function __construct(public readonly string $value) {}
}

$instance = instantiate(Name::class, 'Jane Doe');
$jsonEncoded = json_encode($instance);
assert($jsonEncoded === '{"value":"Jane Doe"}');

$normalized = (new Normalizer())->normalize($instance);
assert($normalized === 'Jane Doe');

$normalizedJson = (new Normalizer())->toJson($instance);
assert($normalizedJson === '"Jane Doe"');
```

Resolves: #38