### PR TITLE
FEATURE: Adjust `Normalizer` to respect `JsonSerializable` interface

### DIFF
--- a/tests/Fixture/Fixture.php
+++ b/tests/Fixture/Fixture.php
@@ -9,6 +9,7 @@ namespace Wwwision\Types\Tests\Fixture;
 use ArrayIterator;
 use DateTimeImmutable;
 use IteratorAggregate;
+use JsonSerializable;
 use stdClass;
 use Traversable;
 use Wwwision\Types\Attributes\Description;
@@ -618,4 +619,35 @@ final class SubClassWithRecursion
         #[Description('recursive property')]
         public readonly ClassWithRecursion $parentClass,
     ) {}
+}
+
+final class JsonSerializableShape implements JsonSerializable
+{
+    public function __construct(
+        public readonly JsonSerializableSimpleShape $name,
+        public readonly int $age,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'name' => $this->name,
+            'age' => $this->age,
+        ];
+    }
+}
+
+final class JsonSerializableSimpleShape implements JsonSerializable
+{
+    public function __construct(
+        public readonly string $name,
+    ) {}
+
+    public function jsonSerialize(): string
+    {
+        return strtoupper($this->name);
+    }
 }

--- a/tests/PHPUnit/NormalizerTest.php
+++ b/tests/PHPUnit/NormalizerTest.php
@@ -156,4 +156,11 @@ final class NormalizerTest extends TestCase
         self::assertSame(['t' => null], $actualResult);
     }
 
+    public function test_normalize_respects_jsonSerializable_properties(): void
+    {
+        $instance = new Fixture\JsonSerializableShape(new Fixture\JsonSerializableSimpleShape('some name'), 123);
+        $actualResult = (new Normalizer())->normalize($instance);
+        self::assertSame(['name' => 'SOME NAME', 'age' => 123], $actualResult);
+    }
+
 }


### PR DESCRIPTION
If a class implements `JsonSerializable` the normalizer will use the result of `jsonSerialize()` when normalizing an instance.

This allows for some simple manipulation of the normalized/json representation