### PR TITLE
FEATURE: "examples" for string, integer & float based schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,12 +266,13 @@ It has the optional arguments
 
 * `minimum` – to specify the allowed _minimum_ value
 * `maximum` – to specify the allowed _maximum_ value
+* `examples`- to provide valid example values (since version [1.7](https://github.com/bwaidelich/types/releases/tag/1.7.0))
 
 <details>
 <summary><b>Example</b></summary>
 
 ```php
-#[IntegerBased(minimum: 0, maximum: 123)]
+#[IntegerBased(minimum: 0, maximum: 123, examples: [0, 22, 123])]
 final class SomeIntBased {
     private function __construct(public readonly int $value) {}
 }
@@ -292,12 +293,13 @@ It has the optional arguments
 
 * `minimum` – to specify the allowed _minimum_ value (as integer or float)
 * `maximum` – to specify the allowed _maximum_ value (as integer or float)
+* `examples`- to provide valid example values (since version [1.7](https://github.com/bwaidelich/types/releases/tag/1.7.0))
 
 <details>
 <summary><b>Example</b></summary>
 
 ```php
-#[FloatBased(minimum: 12.34, maximum: 30)]
+#[FloatBased(minimum: 12.34, maximum: 30, examples: [23.345, 6, 7.89])]
 final class SomeFloatBased {
     private function __construct(public readonly float $value) {}
 }
@@ -320,6 +322,7 @@ It has the optional arguments
 * `pattern` – to specify a regular expression that the string has to match
 * `format` – one of the predefined formats the string has to satisfy (this is a subset of
   the [JSON Schema string format](https://json-schema.org/understanding-json-schema/reference/string.html#format))
+* `examples`- to provide valid example values (since version [1.7](https://github.com/bwaidelich/types/releases/tag/1.7.0))
 
 <details>
 <summary><b>Example: String Value Object with min and max length constraints</b></summary>
@@ -343,7 +346,7 @@ instantiate(GivenName::class, '');
 Just like with JSON Schema, `format` and `pattern` can be _combined_ to further narrow the type:
 
 ```php
-#[StringBased(format: StringTypeFormat::email, pattern: '@your.org$')]
+#[StringBased(format: StringTypeFormat::email, pattern: '@your.org$', examples: ['john.doe@your.org', 'jane.doe@your.org'])]
 final class EmployeeEmailAddress {
     private function __construct(public readonly string $value) {}
 }

--- a/src/Attributes/FloatBased.php
+++ b/src/Attributes/FloatBased.php
@@ -9,8 +9,12 @@ use Attribute;
 #[Attribute(Attribute::TARGET_CLASS)]
 final class FloatBased implements TypeBased
 {
+    /**
+     * @param array<float|int>|null $examples
+     */
     public function __construct(
         public readonly float|int|null $minimum = null,
         public readonly float|int|null $maximum = null,
+        public readonly array|null $examples = null,
     ) {}
 }

--- a/src/Attributes/IntegerBased.php
+++ b/src/Attributes/IntegerBased.php
@@ -9,8 +9,12 @@ use Attribute;
 #[Attribute(Attribute::TARGET_CLASS)]
 final class IntegerBased implements TypeBased
 {
+    /**
+     * @param array<int>|null $examples
+     */
     public function __construct(
         public readonly null|int $minimum = null,
         public readonly null|int $maximum = null,
+        public readonly null|array $examples = null,
     ) {}
 }

--- a/src/Attributes/StringBased.php
+++ b/src/Attributes/StringBased.php
@@ -10,10 +10,14 @@ use Wwwision\Types\Schema\StringTypeFormat;
 #[Attribute(Attribute::TARGET_CLASS)]
 final class StringBased implements TypeBased
 {
+    /**
+     * @param array<string>|null $examples
+     */
     public function __construct(
         public readonly null|int $minLength = null,
         public readonly null|int $maxLength = null,
         public readonly null|string $pattern = null,
         public readonly null|StringTypeFormat $format = null,
+        public readonly null|array $examples = null,
     ) {}
 }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -123,9 +123,9 @@ final class Parser
             Assert::count($baseTypeAttributes, 1, 'Expected exactly %d BaseType attribute for class "' . $reflectionClass->getName() . '", got %d');
             $baseTypeAttribute = $baseTypeAttributes[0]->newInstance();
             $schema = match ($baseTypeAttribute::class) {
-                StringBased::class => new StringSchema($reflectionClass, self::getDescription($reflectionClass), $baseTypeAttribute->minLength, $baseTypeAttribute->maxLength, $baseTypeAttribute->pattern, $baseTypeAttribute->format),
-                IntegerBased::class => new IntegerSchema($reflectionClass, self::getDescription($reflectionClass), $baseTypeAttribute->minimum, $baseTypeAttribute->maximum),
-                FloatBased::class => new FloatSchema($reflectionClass, self::getDescription($reflectionClass), $baseTypeAttribute->minimum, $baseTypeAttribute->maximum),
+                StringBased::class => new StringSchema($reflectionClass, self::getDescription($reflectionClass), $baseTypeAttribute->minLength, $baseTypeAttribute->maxLength, $baseTypeAttribute->pattern, $baseTypeAttribute->format, $baseTypeAttribute->examples),
+                IntegerBased::class => new IntegerSchema($reflectionClass, self::getDescription($reflectionClass), $baseTypeAttribute->minimum, $baseTypeAttribute->maximum, $baseTypeAttribute->examples),
+                FloatBased::class => new FloatSchema($reflectionClass, self::getDescription($reflectionClass), $baseTypeAttribute->minimum, $baseTypeAttribute->maximum, $baseTypeAttribute->examples),
                 ListBased::class => new ListSchema(
                     $reflectionClass,
                     self::getDescription($reflectionClass),

--- a/src/Schema/FloatSchema.php
+++ b/src/Schema/FloatSchema.php
@@ -22,12 +22,14 @@ final class FloatSchema implements Schema
 {
     /**
      * @param ReflectionClass<object> $reflectionClass
+     * @param array<float|int>|null $examples
      */
     public function __construct(
         private readonly ReflectionClass $reflectionClass,
         public readonly null|string $description,
         public readonly float|int|null $minimum = null,
         public readonly float|int|null $maximum = null,
+        public readonly array|null $examples = null,
     ) {}
 
     public function getType(): string
@@ -109,6 +111,9 @@ final class FloatSchema implements Schema
         }
         if ($this->maximum !== null) {
             $result['maximum'] = $this->maximum;
+        }
+        if ($this->examples !== null) {
+            $result['examples'] = $this->examples;
         }
         return $result;
     }

--- a/src/Schema/IntegerSchema.php
+++ b/src/Schema/IntegerSchema.php
@@ -22,12 +22,14 @@ final class IntegerSchema implements Schema
 {
     /**
      * @param ReflectionClass<object> $reflectionClass
+     * @param array<int>|null $examples
      */
     public function __construct(
         private readonly ReflectionClass $reflectionClass,
         public readonly null|string $description,
         public readonly null|int $minimum = null,
         public readonly null|int $maximum = null,
+        public readonly null|array $examples = null,
     ) {}
 
     public function getType(): string
@@ -113,6 +115,9 @@ final class IntegerSchema implements Schema
         }
         if ($this->maximum !== null) {
             $result['maximum'] = $this->maximum;
+        }
+        if ($this->examples !== null) {
+            $result['examples'] = $this->examples;
         }
         return $result;
     }

--- a/src/Schema/StringSchema.php
+++ b/src/Schema/StringSchema.php
@@ -27,6 +27,7 @@ final class StringSchema implements Schema
 {
     /**
      * @param ReflectionClass<object> $reflectionClass
+     * @param array<string>|null $examples
      */
     public function __construct(
         private readonly ReflectionClass $reflectionClass,
@@ -35,6 +36,7 @@ final class StringSchema implements Schema
         public readonly null|int $maxLength = null,
         public readonly null|string $pattern = null,
         public readonly null|StringTypeFormat $format = null,
+        public readonly null|array $examples = null,
     ) {}
 
     public function getType(): string
@@ -145,6 +147,9 @@ final class StringSchema implements Schema
         }
         if ($this->format !== null) {
             $result['format'] = $this->format->name;
+        }
+        if ($this->examples !== null) {
+            $result['examples'] = $this->examples;
         }
         return $result;
     }

--- a/tests/Fixture/Fixture.php
+++ b/tests/Fixture/Fixture.php
@@ -24,7 +24,7 @@ use Wwwision\Types\Schema\StringTypeFormat;
 
 use function Wwwision\Types\instantiate;
 
-#[StringBased(minLength: 3, maxLength: 20)]
+#[StringBased(minLength: 3, maxLength: 20, examples: ['John', 'Jane'])]
 #[Description('First name of a person')]
 final class GivenName implements SomeInterface
 {
@@ -58,7 +58,7 @@ final class FamilyName implements SomeInterface
     }
 }
 
-#[IntegerBased(minimum: 1, maximum: 120)]
+#[IntegerBased(minimum: 1, maximum: 120, examples: [123, 321])]
 #[Description('The age of a person in years')]
 final class Age
 {
@@ -332,7 +332,7 @@ interface SomeInterface
     public function someOtherMethod(): null|FamilyName;
 }
 
-#[FloatBased(minimum: -180.0, maximum: 180.5)]
+#[FloatBased(minimum: -180.0, maximum: 180.5, examples: [77.0369])]
 final class Longitude
 {
     private function __construct(

--- a/tests/PHPUnit/IntegrationTest.php
+++ b/tests/PHPUnit/IntegrationTest.php
@@ -155,14 +155,14 @@ final class IntegrationTest extends TestCase
         yield 'int backed enum' => ['className' => Fixture\Number::class, 'expectedResult' => '{"type":"enum","name":"Number","description":"A number","cases":[{"type":"integer","description":"The number 1","name":"ONE","value":1},{"type":"integer","description":null,"name":"TWO","value":2},{"type":"integer","description":null,"name":"THREE","value":3}]}'];
         yield 'string backed enum' => ['className' => Fixture\RomanNumber::class, 'expectedResult' => '{"type":"enum","name":"RomanNumber","description":null,"cases":[{"type":"string","description":null,"name":"I","value":"1"},{"type":"string","description":"random description","name":"II","value":"2"},{"type":"string","description":null,"name":"III","value":"3"},{"type":"string","description":null,"name":"IV","value":"4"}]}'];
 
-        yield 'float based object' => ['className' => Fixture\Longitude::class, 'expectedResult' => '{"type":"float","name":"Longitude","description":null,"minimum":-180,"maximum":180.5}'];
-        yield 'integer based object' => ['className' => Fixture\Age::class, 'expectedResult' => '{"type":"integer","name":"Age","description":"The age of a person in years","minimum":1,"maximum":120}'];
+        yield 'float based object' => ['className' => Fixture\Longitude::class, 'expectedResult' => '{"type":"float","name":"Longitude","description":null,"minimum":-180,"maximum":180.5,"examples":[77.0369]}'];
+        yield 'integer based object' => ['className' => Fixture\Age::class, 'expectedResult' => '{"type":"integer","name":"Age","description":"The age of a person in years","minimum":1,"maximum":120,"examples":[123,321]}'];
         yield 'list object' => ['className' => Fixture\FullNames::class, 'expectedResult' => '{"type":"array","name":"FullNames","description":null,"itemType":"FullName","minCount":2,"maxCount":5}'];
         yield 'list of interfaces' => ['className' => Fixture\InterfaceList::class, 'expectedResult' => '{"type":"array","name":"InterfaceList","description":null,"itemType":"ItemInterface"}'];
         yield 'shape object' => ['className' => Fixture\FullName::class, 'expectedResult' => '{"type":"object","name":"FullName","description":"First and last name of a person","properties":[{"type":"GivenName","name":"givenName","description":"First name of a person"},{"type":"FamilyName","name":"familyName","description":"Last name of a person"}]}'];
         yield 'shape object with optional properties' => ['className' => Fixture\ShapeWithOptionalTypes::class, 'expectedResult' => '{"type":"object","name":"ShapeWithOptionalTypes","description":null,"properties":[{"type":"FamilyName","name":"stringBased","description":"Last name of a person"},{"type":"FamilyName|null","name":"stringBasedOrNull","description":null},{"type":"string|null","name":"stringOrNull","description":null},{"type":"GivenNames|null","name":"givenNamesOrNull","description":null},{"type":"FamilyName","name":"optionalStringBased","description":"Last name of a person","optional":true},{"type":"int","name":"optionalInt","description":"Some description","optional":true},{"type":"boolean","name":"optionalBool","description":null,"optional":true},{"type":"string","name":"optionalString","description":null,"optional":true},{"type":"string","name":"stringWithDefaultValue","description":null,"optional":true},{"type":"boolean","name":"boolWithDefault","description":null,"optional":true}]}'];
 
-        yield 'string based object' => ['className' => Fixture\GivenName::class, 'expectedResult' => '{"type":"string","name":"GivenName","description":"First name of a person","minLength":3,"maxLength":20}'];
+        yield 'string based object' => ['className' => Fixture\GivenName::class, 'expectedResult' => '{"type":"string","name":"GivenName","description":"First name of a person","minLength":3,"maxLength":20,"examples":["John","Jane"]}'];
         yield 'string based object with format' => ['className' => Fixture\EmailAddress::class, 'expectedResult' => '{"type":"string","name":"EmailAddress","description":null,"format":"email"}'];
         yield 'string based object with pattern' => ['className' => Fixture\NotMagic::class, 'expectedResult' => '{"type":"string","name":"NotMagic","description":null,"pattern":"^(?!magic).*"}'];
 
@@ -1169,7 +1169,8 @@ final class IntegrationTest extends TestCase
                     "maxLength": 20,
                     "minLength": 3,
                     "name": "GivenName",
-                    "type": "string"
+                    "type": "string",
+                    "examples": ["John", "Jane"]
                 },
                 {
                     "description": "Last name of a person",


### PR DESCRIPTION
Extends the `StringBased`, `IntegerBased` and `FloatBased` attributes by an "example" property that allows to specify valid values

## Example:

```php
#[StringBased(examples: ["John", "Jane"])]
final readonly class GivenName {
    // ...
}
```