### PR TITLE
FEATURE: Add `Ignore` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,39 @@ $instance = instantiate(Composite::class, ['property1' => 'foo', 'property2' => 
 assert($instance instanceof Composite);
 ```
 
+### Skip interface methods
+
+When trying to generate a schema for an interface, public methods are considered properties of that schema.
+As a result, an exception will be thrown if the interface contains methods with parameters because those cannot be represented as properties:
+
+```php
+interface SomeInterface {
+    public function someMethodWithParameter(string $parameter): bool;
+}
+try {
+    $schema = Parser::getSchema(SomeInterface::class);
+} catch (\Exception $e) {
+    $exception = $e->getMessage();
+}
+assert(str_starts_with($exception, 'Method "someMethodWithParameter" of interface "'));
+assert(str_ends_with($exception, 'SomeInterface" has at least one parameter, but this is currently not supported – add an #[Ignore] attribute to skip this method'));
+```
+
+Starting with version [1.9](https://github.com/bwaidelich/types/releases/tag/1.9.0), those cases can be ignored by adding the `#[Ignore]` attribute to the method:
+
+```php
+use Wwwision\Types\Attributes\Ignore;
+
+interface SomeInterface {
+    #[Ignore]
+    public function someMethodWithParameter(string $parameter): bool;
+}
+
+$schema = Parser::getSchema(SomeInterface::class);
+assert($schema instanceof \Wwwision\Types\Schema\InterfaceSchema);
+assert($schema->propertySchemas === []);
+```
+
 ## Generics
 
 Generics won't make it into PHP most likely (see this [video from Brent](https://www.youtube.com/watch?v=JtmRG5lCENA) that explains why that is the case).

--- a/src/Attributes/Ignore.php
+++ b/src/Attributes/Ignore.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\Types\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class Ignore {}

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -16,10 +16,12 @@ use ReflectionNamedType;
 use ReflectionParameter;
 use ReflectionType;
 use ReflectionUnionType;
+use RuntimeException;
 use Webmozart\Assert\Assert;
 use Wwwision\Types\Attributes\Description;
 use Wwwision\Types\Attributes\Discriminator;
 use Wwwision\Types\Attributes\FloatBased;
+use Wwwision\Types\Attributes\Ignore;
 use Wwwision\Types\Attributes\IntegerBased;
 use Wwwision\Types\Attributes\ListBased;
 use Wwwision\Types\Attributes\StringBased;
@@ -230,7 +232,12 @@ final class Parser
         $propertySchemas = [];
         $overriddenPropertyDescriptions = [];
         foreach ($interfaceReflection->getMethods(ReflectionMethod::IS_PUBLIC) as $reflectionMethod) {
-            Assert::isEmpty($reflectionMethod->getParameters(), sprintf('Method "%s" of interface "%s" has at least one parameter, but this is currently not supported', $reflectionMethod->getName(), $interfaceReflection->getName()));
+            if ($reflectionMethod->getAttributes(Ignore::class) !== []) {
+                continue;
+            }
+            if ($reflectionMethod->getNumberOfParameters() !== 0) {
+                throw new RuntimeException(sprintf('Method "%s" of interface "%s" has at least one parameter, but this is currently not supported – add an #[Ignore] attribute to skip this method', $reflectionMethod->getName(), $interfaceReflection->getName()));
+            }
             $propertyName = $reflectionMethod->getName();
             $returnType = $reflectionMethod->getReturnType();
             Assert::notNull($returnType, sprintf('Return type of method "%s" of interface "%s" is missing', $reflectionMethod->getName(), $interfaceReflection->getName()));

--- a/tests/Fixture/Fixture.php
+++ b/tests/Fixture/Fixture.php
@@ -15,6 +15,7 @@ use Traversable;
 use Wwwision\Types\Attributes\Description;
 use Wwwision\Types\Attributes\Discriminator;
 use Wwwision\Types\Attributes\FloatBased;
+use Wwwision\Types\Attributes\Ignore;
 use Wwwision\Types\Attributes\IntegerBased;
 use Wwwision\Types\Attributes\ListBased;
 use Wwwision\Types\Attributes\StringBased;
@@ -356,9 +357,17 @@ final class GeoCoordinates
     ) {}
 }
 
-interface SomeInvalidInterface
+interface SomeInterfaceWithParameterizedMethod
 {
     public function methodWithParameters(string|null $param = null): string;
+    public function methodWithoutParameters(): string;
+}
+
+interface SomeInterfaceWithIgnoredParameterizedMethod
+{
+    #[Ignore]
+    public function methodWithParameters(string|null $param = null): string;
+    public function methodWithoutParameters(): string;
 }
 
 #[StringBased(minLength: 10, maxLength: 2, pattern: '^foo$', format: StringTypeFormat::email)]

--- a/tests/PHPUnit/IntegrationTest.php
+++ b/tests/PHPUnit/IntegrationTest.php
@@ -131,9 +131,17 @@ final class IntegrationTest extends TestCase
      */
     public function test_getSchema_throws_if_given_class_is_interface_with_parameterized_methods(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Method "methodWithParameters" of interface "Wwwision\Types\Tests\Fixture\SomeInvalidInterface" has at least one parameter, but this is currently not supported');
-        Parser::getSchema(Fixture\SomeInvalidInterface::class);
+        $this->expectExceptionMessage('Method "methodWithParameters" of interface "Wwwision\Types\Tests\Fixture\SomeInterfaceWithParameterizedMethod" has at least one parameter, but this is currently not supported – add an #[Ignore] attribute to skip this method');
+        Parser::getSchema(Fixture\SomeInterfaceWithParameterizedMethod::class);
+    }
+
+    public function test_getSchema_skips_parameterized_methods_if_instructed(): void
+    {
+        $schema = Parser::getSchema(Fixture\SomeInterfaceWithIgnoredParameterizedMethod::class);
+        self::assertInstanceOf(InterfaceSchema::class, $schema);
+        self::assertArrayNotHasKey('methodWithParameters', $schema->propertySchemas);
+        self::assertArrayHasKey('methodWithoutParameters', $schema->propertySchemas);
+        self::assertInstanceOf(LiteralStringSchema::class, $schema->propertySchemas['methodWithoutParameters']);
     }
 
     public function test_getSchema_throws_if_shape_has_no_constructor(): void


### PR DESCRIPTION
For now, this attribute can be used to skip parametrized methods in interfaces:

```php
interface SomeInterface {
    #[Ignore]
    public function someMethodWithParameter(string $parameter): bool;
}
```