### PR TITLE
FEATURE: Add `extensions` argument to type-based attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ It has the optional arguments
 * `minimum` – to specify the allowed _minimum_ value
 * `maximum` – to specify the allowed _maximum_ value
 * `examples`- to provide valid example values (since version [1.7](https://github.com/bwaidelich/types/releases/tag/1.7.0))
+* `extensions` – to attach custom key/value pairs to the schema (see [Schema extensions](#schema-extensions))
 
 <details>
 <summary><b>Example</b></summary>
@@ -302,6 +303,7 @@ It has the optional arguments
 * `minimum` – to specify the allowed _minimum_ value (as integer or float)
 * `maximum` – to specify the allowed _maximum_ value (as integer or float)
 * `examples`- to provide valid example values (since version [1.7](https://github.com/bwaidelich/types/releases/tag/1.7.0))
+* `extensions` – to attach custom key/value pairs to the schema (see [Schema extensions](#schema-extensions))
 
 <details>
 <summary><b>Example</b></summary>
@@ -331,6 +333,7 @@ It has the optional arguments
 * `format` – one of the predefined formats the string has to satisfy (this is a subset of
   the [JSON Schema string format](https://json-schema.org/understanding-json-schema/reference/string.html#format))
 * `examples`- to provide valid example values (since version [1.7](https://github.com/bwaidelich/types/releases/tag/1.7.0))
+* `extensions` – to attach custom key/value pairs to the schema (see [Schema extensions](#schema-extensions))
 
 <details>
 <summary><b>Example: String Value Object with min and max length constraints</b></summary>
@@ -374,6 +377,7 @@ It has the optional arguments
 
 * `minCount` – to specify how many items the list has to contain _at least_
 * `maxCount` – to specify how many items the list has to contain _at most_
+* `extensions` – to attach custom key/value pairs to the schema (see [Schema extensions](#schema-extensions))
 
 <details>
 <summary><b>Example: Simple generic array</b></summary>
@@ -437,6 +441,30 @@ final class HobbiesAdvanced implements IteratorAggregate, Countable, JsonSeriali
 instantiate(HobbiesAdvanced::class, ['Soccer', 'Ping Pong', 'Guitar', 'Gaming']);
 
 // Exception: Failed to cast value of type array to HobbiesAdvanced: too_big (Array must contain at most 3 element(s))
+```
+
+</details>
+
+### Schema extensions
+
+Starting with version [1.10](https://github.com/bwaidelich/types/releases/tag/1.10.0), the [IntegerBased](#integerbased), [FloatBased](#floatbased), [StringBased](#stringbased) and [ListBased](#listbased) attributes accept an optional `extensions` argument: an associative array of arbitrary key/value pairs that are merged into the schema's JSON representation.
+
+This is useful when translating the schema for downstream tooling (for example, [JSON Schema](https://json-schema.org) or [OpenAPI specification extensions](https://spec.openapis.org/oas/v3.1.0#specification-extensions), which use the `x-` prefix for vendor-specific keys).
+
+The values are also accessible on the corresponding `Schema` instance via the `$extensions` property.
+
+<details>
+<summary><b>Example: Custom editor hint via an OpenAPI-style extension</b></summary>
+
+```php
+#[StringBased(format: StringTypeFormat::uri, extensions: ['x-editor' => 'ImageEditor'])]
+final class ImageUrl {
+    private function __construct(public readonly string $value) {}
+}
+
+$schema = Parser::getSchema(ImageUrl::class);
+assert($schema->extensions === ['x-editor' => 'ImageEditor']);
+assert(json_encode($schema) === '{"type":"string","name":"ImageUrl","description":null,"format":"uri","x-editor":"ImageEditor"}');
 ```
 
 </details>

--- a/src/Attributes/FloatBased.php
+++ b/src/Attributes/FloatBased.php
@@ -11,10 +11,12 @@ final class FloatBased implements TypeBased
 {
     /**
      * @param array<float|int>|null $examples
+     * @param array<string, mixed>|null $extensions
      */
     public function __construct(
         public readonly float|int|null $minimum = null,
         public readonly float|int|null $maximum = null,
         public readonly array|null $examples = null,
+        public readonly array|null $extensions = null,
     ) {}
 }

--- a/src/Attributes/IntegerBased.php
+++ b/src/Attributes/IntegerBased.php
@@ -11,10 +11,12 @@ final class IntegerBased implements TypeBased
 {
     /**
      * @param array<int>|null $examples
+     * @param array<string, mixed>|null $extensions
      */
     public function __construct(
         public readonly int|null $minimum = null,
         public readonly int|null $maximum = null,
         public readonly array|null $examples = null,
+        public readonly array|null $extensions = null,
     ) {}
 }

--- a/src/Attributes/ListBased.php
+++ b/src/Attributes/ListBased.php
@@ -11,10 +11,12 @@ final class ListBased implements TypeBased
 {
     /**
      * @param class-string<object> $itemClassName
+     * @param array<string, mixed>|null $extensions
      */
     public function __construct(
         public readonly string $itemClassName,
         public readonly int|null $minCount = null,
         public readonly int|null $maxCount = null,
+        public readonly array|null $extensions = null,
     ) {}
 }

--- a/src/Attributes/StringBased.php
+++ b/src/Attributes/StringBased.php
@@ -12,6 +12,7 @@ final class StringBased implements TypeBased
 {
     /**
      * @param array<string>|null $examples
+     * @param array<string, mixed>|null $extensions
      */
     public function __construct(
         public readonly int|null $minLength = null,
@@ -19,5 +20,6 @@ final class StringBased implements TypeBased
         public readonly string|null $pattern = null,
         public readonly StringTypeFormat|null $format = null,
         public readonly array|null $examples = null,
+        public readonly array|null $extensions = null,
     ) {}
 }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -133,15 +133,16 @@ final class Parser
             Assert::count($baseTypeAttributes, 1, 'Expected exactly %d BaseType attribute for class "' . $reflectionClass->getName() . '", got %d');
             $baseTypeAttribute = $baseTypeAttributes[0]->newInstance();
             return match ($baseTypeAttribute::class) {
-                StringBased::class => new StringSchema($reflectionClass, self::getDescription($reflectionClass), $baseTypeAttribute->minLength, $baseTypeAttribute->maxLength, $baseTypeAttribute->pattern, $baseTypeAttribute->format, $baseTypeAttribute->examples),
-                IntegerBased::class => new IntegerSchema($reflectionClass, self::getDescription($reflectionClass), $baseTypeAttribute->minimum, $baseTypeAttribute->maximum, $baseTypeAttribute->examples),
-                FloatBased::class => new FloatSchema($reflectionClass, self::getDescription($reflectionClass), $baseTypeAttribute->minimum, $baseTypeAttribute->maximum, $baseTypeAttribute->examples),
+                StringBased::class => new StringSchema($reflectionClass, self::getDescription($reflectionClass), $baseTypeAttribute->minLength, $baseTypeAttribute->maxLength, $baseTypeAttribute->pattern, $baseTypeAttribute->format, $baseTypeAttribute->examples, $baseTypeAttribute->extensions),
+                IntegerBased::class => new IntegerSchema($reflectionClass, self::getDescription($reflectionClass), $baseTypeAttribute->minimum, $baseTypeAttribute->maximum, $baseTypeAttribute->examples, $baseTypeAttribute->extensions),
+                FloatBased::class => new FloatSchema($reflectionClass, self::getDescription($reflectionClass), $baseTypeAttribute->minimum, $baseTypeAttribute->maximum, $baseTypeAttribute->examples, $baseTypeAttribute->extensions),
                 ListBased::class => new ListSchema(
                     $reflectionClass,
                     self::getDescription($reflectionClass),
                     self::getSchema($baseTypeAttribute->itemClassName),
                     $baseTypeAttribute->minCount,
                     $baseTypeAttribute->maxCount,
+                    $baseTypeAttribute->extensions,
                 ),
                 default => throw new InvalidArgumentException(sprintf('BaseType attribute for class "%s" has an invalid type of %s', $reflectionClass->getName(), get_debug_type($baseTypeAttribute)), 1688559710),
             };

--- a/src/Schema/FloatSchema.php
+++ b/src/Schema/FloatSchema.php
@@ -25,6 +25,7 @@ final class FloatSchema implements Schema
     /**
      * @param ReflectionClass<object> $reflectionClass
      * @param array<float|int>|null $examples
+     * @param array<string, mixed>|null $extensions
      */
     public function __construct(
         private readonly ReflectionClass $reflectionClass,
@@ -32,6 +33,7 @@ final class FloatSchema implements Schema
         public readonly float|int|null $minimum = null,
         public readonly float|int|null $maximum = null,
         public readonly array|null $examples = null,
+        public readonly array|null $extensions = null,
     ) {}
 
     public function getType(): string
@@ -116,6 +118,9 @@ final class FloatSchema implements Schema
         }
         if ($this->examples !== null) {
             $result['examples'] = $this->examples;
+        }
+        if ($this->extensions !== null) {
+            $result += $this->extensions;
         }
         return $result;
     }

--- a/src/Schema/IntegerSchema.php
+++ b/src/Schema/IntegerSchema.php
@@ -25,6 +25,7 @@ final class IntegerSchema implements Schema
     /**
      * @param ReflectionClass<object> $reflectionClass
      * @param array<int>|null $examples
+     * @param array<string, mixed>|null $extensions
      */
     public function __construct(
         private readonly ReflectionClass $reflectionClass,
@@ -32,6 +33,7 @@ final class IntegerSchema implements Schema
         public readonly int|null $minimum = null,
         public readonly int|null $maximum = null,
         public readonly array|null $examples = null,
+        public readonly array|null $extensions = null,
     ) {}
 
     public function getType(): string
@@ -120,6 +122,9 @@ final class IntegerSchema implements Schema
         }
         if ($this->examples !== null) {
             $result['examples'] = $this->examples;
+        }
+        if ($this->extensions !== null) {
+            $result += $this->extensions;
         }
         return $result;
     }

--- a/src/Schema/ListSchema.php
+++ b/src/Schema/ListSchema.php
@@ -21,6 +21,7 @@ final class ListSchema implements Schema
 {
     /**
      * @param ReflectionClass<object> $reflectionClass
+     * @param array<string, mixed>|null $extensions
      */
     public function __construct(
         private readonly ReflectionClass $reflectionClass,
@@ -28,6 +29,7 @@ final class ListSchema implements Schema
         public readonly Schema $itemSchema,
         public readonly int|null $minCount = null,
         public readonly int|null $maxCount = null,
+        public readonly array|null $extensions = null,
     ) {}
 
     public function getType(): string
@@ -114,6 +116,9 @@ final class ListSchema implements Schema
         }
         if ($this->maxCount !== null) {
             $result['maxCount'] = $this->maxCount;
+        }
+        if ($this->extensions !== null) {
+            $result += $this->extensions;
         }
         return $result;
     }

--- a/src/Schema/StringSchema.php
+++ b/src/Schema/StringSchema.php
@@ -30,6 +30,7 @@ final class StringSchema implements Schema
     /**
      * @param ReflectionClass<object> $reflectionClass
      * @param array<string>|null $examples
+     * @param array<string, mixed>|null $extensions
      */
     public function __construct(
         private readonly ReflectionClass $reflectionClass,
@@ -39,6 +40,7 @@ final class StringSchema implements Schema
         public readonly string|null $pattern = null,
         public readonly StringTypeFormat|null $format = null,
         public readonly array|null $examples = null,
+        public readonly array|null $extensions = null,
     ) {}
 
     public function getType(): string
@@ -152,6 +154,9 @@ final class StringSchema implements Schema
         }
         if ($this->examples !== null) {
             $result['examples'] = $this->examples;
+        }
+        if ($this->extensions !== null) {
+            $result += $this->extensions;
         }
         return $result;
     }

--- a/tests/Fixture/Fixture.php
+++ b/tests/Fixture/Fixture.php
@@ -669,3 +669,36 @@ final class JsonSerializableSimpleShape implements JsonSerializable
         return strtoupper($this->name);
     }
 }
+
+#[StringBased(extensions: ['x-editor' => 'ImageEditor', 'x-mime' => 'image/png'])]
+final class ImageUrl
+{
+    private function __construct(public readonly string $value) {}
+}
+
+#[IntegerBased(extensions: ['x-unit' => 'seconds'])]
+final class TimeoutSeconds
+{
+    private function __construct(public readonly int $value) {}
+}
+
+#[FloatBased(extensions: ['x-unit' => 'celsius'])]
+final class Temperature
+{
+    private function __construct(public readonly float $value) {}
+}
+
+/**
+ * @implements IteratorAggregate<GivenName>
+ */
+#[ListBased(itemClassName: GivenName::class, extensions: ['x-widget' => 'TagInput'])]
+final class TaggedGivenNames implements IteratorAggregate
+{
+    /** @param array<GivenName> $givenNames */
+    private function __construct(private readonly array $givenNames) {}
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->givenNames);
+    }
+}

--- a/tests/PHPUnit/IntegrationTest.php
+++ b/tests/PHPUnit/IntegrationTest.php
@@ -194,6 +194,58 @@ final class IntegrationTest extends TestCase
         yield 'interface with discriminator' => ['className' => Fixture\InterfaceWithDiscriminator::class, 'expectedResult' => '{"type":"interface","name":"InterfaceWithDiscriminator","description":null,"properties":[]}'];
         yield 'shape with recursion' => ['className' => Fixture\ClassWithRecursion::class, 'expectedResult' => '{"type":"object","name":"ClassWithRecursion","description":"Description on recursive class","properties":[{"type":"SubClassWithRecursion","name":"subClass","description":null}]}'];
         yield 'shape with recursion 2' => ['className' => Fixture\SubClassWithRecursion::class, 'expectedResult' => '{"type":"object","name":"SubClassWithRecursion","description":null,"properties":[{"type":"ClassWithRecursion","name":"parentClass","description":"Description on recursive class"}]}'];
+
+        yield 'string based object with extensions' => ['className' => Fixture\ImageUrl::class, 'expectedResult' => '{"type":"string","name":"ImageUrl","description":null,"x-editor":"ImageEditor","x-mime":"image/png"}'];
+        yield 'integer based object with extensions' => ['className' => Fixture\TimeoutSeconds::class, 'expectedResult' => '{"type":"integer","name":"TimeoutSeconds","description":null,"x-unit":"seconds"}'];
+        yield 'float based object with extensions' => ['className' => Fixture\Temperature::class, 'expectedResult' => '{"type":"float","name":"Temperature","description":null,"x-unit":"celsius"}'];
+        yield 'list object with extensions' => ['className' => Fixture\TaggedGivenNames::class, 'expectedResult' => '{"type":"array","name":"TaggedGivenNames","description":null,"itemType":"GivenName","x-widget":"TagInput"}'];
+    }
+
+    public function test_getSchema_exposes_extensions_on_StringSchema(): void
+    {
+        $schema = Parser::getSchema(Fixture\ImageUrl::class);
+        self::assertInstanceOf(StringSchema::class, $schema);
+        self::assertSame(['x-editor' => 'ImageEditor', 'x-mime' => 'image/png'], $schema->extensions);
+    }
+
+    public function test_getSchema_exposes_extensions_on_IntegerSchema(): void
+    {
+        $schema = Parser::getSchema(Fixture\TimeoutSeconds::class);
+        self::assertInstanceOf(IntegerSchema::class, $schema);
+        self::assertSame(['x-unit' => 'seconds'], $schema->extensions);
+    }
+
+    public function test_getSchema_exposes_extensions_on_FloatSchema(): void
+    {
+        $schema = Parser::getSchema(Fixture\Temperature::class);
+        self::assertInstanceOf(FloatSchema::class, $schema);
+        self::assertSame(['x-unit' => 'celsius'], $schema->extensions);
+    }
+
+    public function test_getSchema_exposes_extensions_on_ListSchema(): void
+    {
+        $schema = Parser::getSchema(Fixture\TaggedGivenNames::class);
+        self::assertInstanceOf(ListSchema::class, $schema);
+        self::assertSame(['x-widget' => 'TagInput'], $schema->extensions);
+    }
+
+    public function test_getSchema_returns_null_extensions_when_none_specified(): void
+    {
+        $stringSchema = Parser::getSchema(Fixture\GivenName::class);
+        self::assertInstanceOf(StringSchema::class, $stringSchema);
+        self::assertNull($stringSchema->extensions);
+
+        $integerSchema = Parser::getSchema(Fixture\Age::class);
+        self::assertInstanceOf(IntegerSchema::class, $integerSchema);
+        self::assertNull($integerSchema->extensions);
+
+        $floatSchema = Parser::getSchema(Fixture\Longitude::class);
+        self::assertInstanceOf(FloatSchema::class, $floatSchema);
+        self::assertNull($floatSchema->extensions);
+
+        $listSchema = Parser::getSchema(Fixture\FullNames::class);
+        self::assertInstanceOf(ListSchema::class, $listSchema);
+        self::assertNull($listSchema->extensions);
     }
 
     /**


### PR DESCRIPTION
Allows attaching custom key/value pairs (e.g. `x-editor`) to `IntegerBased`, `FloatBased`, `StringBased` and `ListBased` schemas. The values are merged into the JSON representation and accessible via the `$extensions` property on the corresponding Schema instances.