### PR TITLE
FEATURE: Support property hooks and behavior methods on interfaces

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: [ '8.3', '8.4', '8.5' ]
+        php-versions: [ '8.4', '8.5' ]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -25,14 +25,14 @@ jobs:
           php-version: ${{ matrix.php-versions }}
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Validate composer.json and composer.lock
         run: composer validate --strict
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor
           key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}

--- a/README.md
+++ b/README.md
@@ -570,37 +570,58 @@ $instance = instantiate(Composite::class, ['property1' => 'foo', 'property2' => 
 assert($instance instanceof Composite);
 ```
 
-### Skip interface methods
+### Interface properties
 
-When trying to generate a schema for an interface, public methods are considered properties of that schema.
-As a result, an exception will be thrown if the interface contains methods with parameters because those cannot be represented as properties:
+When generating a schema for an interface, its readable members are considered properties of that schema.
+A member becomes a property if it is either
+
+* a [property hook](https://www.php.net/manual/en/language.oop5.property-hooks.php) with a `get` accessor, or
+* a public, non-static method without parameters whose return type can be mapped to a schema
 
 ```php
 interface SomeInterface {
-    public function someMethodWithParameter(string $parameter): bool;
+    public string $someProperty { get; }
+    public function someMethod(): string;
 }
-try {
-    $schema = Parser::getSchema(SomeInterface::class);
-} catch (\Exception $e) {
-    $exception = $e->getMessage();
-}
-assert(str_starts_with($exception, 'Method "someMethodWithParameter" of interface "'));
-assert(str_ends_with($exception, 'SomeInterface" has at least one parameter, but this is currently not supported – add an #[Ignore] attribute to skip this method'));
+
+$schema = Parser::getSchema(SomeInterface::class);
+assert($schema instanceof \Wwwision\Types\Schema\InterfaceSchema);
+assert(array_keys($schema->propertySchemas) === ['someProperty', 'someMethod']);
 ```
 
-Starting with version [1.9](https://github.com/bwaidelich/types/releases/tag/1.9.0), those cases can be ignored by adding the `#[Ignore]` attribute to the method:
+> **Note**
+> If an interface declares a property hook and a method of the same name, the property hook takes precedence.
+
+All other methods are considered _behavior_ rather than data and are silently skipped.
+This includes methods that have parameters, return `void`, are `static`, or have a return type that cannot be mapped to a schema.
+This makes it possible to generate schemas for interfaces that mix data accessors and behavior – including 3rd party interfaces you cannot change:
 
 ```php
-use Wwwision\Types\Attributes\Ignore;
-
 interface SomeInterface {
-    #[Ignore]
-    public function someMethodWithParameter(string $parameter): bool;
+    public function withParameter(string $parameter): bool; // skipped: has a parameter
+    public function returningVoid(): void;                  // skipped: void return type
+    public static function create(): string;                // skipped: static method
 }
 
 $schema = Parser::getSchema(SomeInterface::class);
 assert($schema instanceof \Wwwision\Types\Schema\InterfaceSchema);
 assert($schema->propertySchemas === []);
+```
+
+To exclude a member that _would_ qualify as a property, add the `#[Ignore]` attribute (supported on methods since version [1.9](https://github.com/bwaidelich/types/releases/tag/1.9.0) and on property hooks since version 1.11):
+
+```php
+use Wwwision\Types\Attributes\Ignore;
+
+interface SomeInterface {
+    public string $included { get; }
+    #[Ignore]
+    public function excluded(): string;
+}
+
+$schema = Parser::getSchema(SomeInterface::class);
+assert($schema instanceof \Wwwision\Types\Schema\InterfaceSchema);
+assert(array_keys($schema->propertySchemas) === ['included']);
 ```
 
 ## Generics

--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ assert($schema instanceof \Wwwision\Types\Schema\InterfaceSchema);
 assert($schema->propertySchemas === []);
 ```
 
-To exclude a member that _would_ qualify as a property, add the `#[Ignore]` attribute (supported on methods since version [1.9](https://github.com/bwaidelich/types/releases/tag/1.9.0) and on property hooks since version 1.11):
+To exclude a member that _would_ qualify as a property, add the `#[Ignore]` attribute (supported on methods since version [1.9](https://github.com/bwaidelich/types/releases/tag/1.9.0) and on property hooks since version [1.11]((https://github.com/bwaidelich/types/releases/tag/1.11.0)):
 
 ```php
 use Wwwision\Types\Attributes\Ignore;

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     }
   ],
   "require": {
-    "php": ">=8.3",
+    "php": ">=8.4",
     "webmozart/assert": "^1.11",
     "ramsey/uuid": "^4.7"
   },

--- a/src/Attributes/Ignore.php
+++ b/src/Attributes/Ignore.php
@@ -6,5 +6,5 @@ namespace Wwwision\Types\Attributes;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_METHOD)]
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY)]
 final class Ignore {}

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -14,9 +14,9 @@ use ReflectionIntersectionType;
 use ReflectionMethod;
 use ReflectionNamedType;
 use ReflectionParameter;
+use ReflectionProperty;
 use ReflectionType;
 use ReflectionUnionType;
-use RuntimeException;
 use Webmozart\Assert\Assert;
 use Wwwision\Types\Attributes\Description;
 use Wwwision\Types\Attributes\Discriminator;
@@ -152,10 +152,10 @@ final class Parser
     }
 
     /**
-     * @param ReflectionParameter|ReflectionClass<object>|ReflectionClassConstant|ReflectionFunctionAbstract|ReflectionEnum<\UnitEnum> $reflection
+     * @param ReflectionParameter|ReflectionProperty|ReflectionClass<object>|ReflectionClassConstant|ReflectionFunctionAbstract|ReflectionEnum<\UnitEnum> $reflection
      * @return string|null
      */
-    private static function getDescription(ReflectionParameter|ReflectionClass|ReflectionClassConstant|ReflectionFunctionAbstract|ReflectionEnum $reflection): string|null
+    private static function getDescription(ReflectionParameter|ReflectionProperty|ReflectionClass|ReflectionClassConstant|ReflectionFunctionAbstract|ReflectionEnum $reflection): string|null
     {
         $descriptionAttributes = $reflection->getAttributes(Description::class, ReflectionAttribute::IS_INSTANCEOF);
         if (!isset($descriptionAttributes[0])) {
@@ -232,18 +232,48 @@ final class Parser
     {
         $propertySchemas = [];
         $overriddenPropertyDescriptions = [];
+        // 1. Schema properties declared via PHP property hooks (e.g. `public string $name { get; }`).
+        foreach ($interfaceReflection->getProperties() as $reflectionProperty) {
+            if ($reflectionProperty->getAttributes(Ignore::class) !== []) {
+                continue;
+            }
+            // Only readable properties (i.e. with a `get` hook) can be represented in the schema
+            if (!array_key_exists('get', $reflectionProperty->getHooks())) {
+                continue;
+            }
+            $propertyName = $reflectionProperty->getName();
+            $propertyType = $reflectionProperty->getType();
+            Assert::isInstanceOfAny($propertyType, [ReflectionNamedType::class, ReflectionUnionType::class], sprintf('Type of property "%s" of interface "%s" was expected to be of type %%2$s. Got: %%s', $propertyName, $interfaceReflection->getName()));
+            /** @var ReflectionNamedType|ReflectionUnionType $propertyType */
+            $propertySchema = self::reflectionTypeToSchema($propertyType);
+            if ($propertyType->allowsNull()) {
+                $propertySchema = new OptionalSchema($propertySchema);
+            }
+            $overwrittenDescription = self::getDescription($reflectionProperty);
+            if ($overwrittenDescription !== null) {
+                $overriddenPropertyDescriptions[$propertyName] = $overwrittenDescription;
+            }
+            $propertySchemas[$propertyName] = $propertySchema;
+        }
+        // 2. Schema properties declared via parameterless getter methods. Any method that does not qualify
+        //    as a readable property (because it returns void, expects parameters, is static or has a return
+        //    type that cannot be mapped to a schema) is silently skipped – it describes behavior, not data.
         foreach ($interfaceReflection->getMethods(ReflectionMethod::IS_PUBLIC) as $reflectionMethod) {
+            $propertyName = $reflectionMethod->getName();
+            // A property hook of the same name takes precedence over the method
+            if (array_key_exists($propertyName, $propertySchemas)) {
+                continue;
+            }
             if ($reflectionMethod->getAttributes(Ignore::class) !== []) {
                 continue;
             }
-            if ($reflectionMethod->getNumberOfParameters() !== 0) {
-                throw new RuntimeException(sprintf('Method "%s" of interface "%s" has at least one parameter, but this is currently not supported – add an #[Ignore] attribute to skip this method', $reflectionMethod->getName(), $interfaceReflection->getName()));
+            if ($reflectionMethod->isStatic() || $reflectionMethod->getNumberOfParameters() !== 0) {
+                continue;
             }
-            $propertyName = $reflectionMethod->getName();
             $returnType = $reflectionMethod->getReturnType();
-            Assert::notNull($returnType, sprintf('Return type of method "%s" of interface "%s" is missing', $reflectionMethod->getName(), $interfaceReflection->getName()));
-            Assert::isInstanceOf($returnType, ReflectionNamedType::class, sprintf('Return type of method "%s" of interface "%s" was expected to be of type %%2$s. Got: %%s', $reflectionMethod->getName(), $interfaceReflection->getName()));
-            /** @var ReflectionNamedType $returnType */
+            if ($returnType === null || !self::isMappableType($returnType)) {
+                continue;
+            }
             $propertySchema = self::reflectionTypeToSchema($returnType);
             if ($returnType->allowsNull()) {
                 $propertySchema = new OptionalSchema($propertySchema);
@@ -256,6 +286,34 @@ final class Parser
         }
         $discriminator = self::getDiscriminator($interfaceReflection);
         return new InterfaceSchema($interfaceReflection, self::getDescription($interfaceReflection), $propertySchemas, $overriddenPropertyDescriptions, $discriminator);
+    }
+
+    /**
+     * Determines whether the given type can be mapped to a {@see Schema} without resolving it.
+     *
+     * This is used to decide whether an interface method qualifies as a (readable) property: only methods
+     * with a mappable return type are turned into properties, all others are treated as behavior and skipped.
+     * The check intentionally only inspects the type itself (not the referenced classes) so that genuine
+     * errors while building the referenced schema still surface instead of being swallowed.
+     */
+    private static function isMappableType(ReflectionType $reflectionType): bool
+    {
+        if ($reflectionType instanceof ReflectionUnionType) {
+            foreach ($reflectionType->getTypes() as $subType) {
+                if (!self::isMappableType($subType)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        if (!$reflectionType instanceof ReflectionNamedType) {
+            // intersection types and any future reflection type are not supported
+            return false;
+        }
+        if ($reflectionType->isBuiltin()) {
+            return in_array($reflectionType->getName(), ['array', 'bool', 'float', 'int', 'string', 'null'], true);
+        }
+        return class_exists($reflectionType->getName()) || interface_exists($reflectionType->getName());
     }
 
     private static function reflectionTypeToSchema(ReflectionType $reflectionType, string|null $description = null): Schema

--- a/tests/Fixture/Fixture.php
+++ b/tests/Fixture/Fixture.php
@@ -370,6 +370,42 @@ interface SomeInterfaceWithIgnoredParameterizedMethod
     public function methodWithoutParameters(): string;
 }
 
+interface SomeInterfaceWithVoidMethod
+{
+    public function name(): GivenName;
+    public function doSomething(): void;
+}
+
+interface SomeInterfaceWithStaticMethod
+{
+    public function name(): GivenName;
+    public static function create(): string;
+}
+
+interface SomeInterfaceWithUnmappableReturnTypes
+{
+    public function name(): GivenName;
+    public function anything(): mixed;
+    public function something(): object;
+}
+
+interface SomeInterfaceWithPropertyHooks
+{
+    public GivenName $givenName { get; }
+    #[Description('Custom description for "familyName"')]
+    public FamilyName $familyName { get; }
+    public Age|null $age { get; }
+    #[Ignore]
+    public GivenName $ignoredProperty { get; }
+    public function doSomething(): void;
+}
+
+interface SomeInterfaceWithCollidingHookAndMethod
+{
+    public GivenName $name { get; }
+    public function name(): FamilyName;
+}
+
 #[StringBased(minLength: 10, maxLength: 2, pattern: '^foo$', format: StringTypeFormat::email)]
 final class ImpossibleString
 {

--- a/tests/PHPUnit/IntegrationTest.php
+++ b/tests/PHPUnit/IntegrationTest.php
@@ -126,13 +126,13 @@ final class IntegrationTest extends TestCase
         Parser::getSchema(Fixture\ShapeWithInvalidObjectProperty::class);
     }
 
-    /**
-     * Note: Currently methods with parameters are not supported, but this can change at some point
-     */
-    public function test_getSchema_throws_if_given_class_is_interface_with_parameterized_methods(): void
+    public function test_getSchema_skips_parameterized_interface_methods(): void
     {
-        $this->expectExceptionMessage('Method "methodWithParameters" of interface "Wwwision\Types\Tests\Fixture\SomeInterfaceWithParameterizedMethod" has at least one parameter, but this is currently not supported – add an #[Ignore] attribute to skip this method');
-        Parser::getSchema(Fixture\SomeInterfaceWithParameterizedMethod::class);
+        $schema = Parser::getSchema(Fixture\SomeInterfaceWithParameterizedMethod::class);
+        self::assertInstanceOf(InterfaceSchema::class, $schema);
+        self::assertArrayNotHasKey('methodWithParameters', $schema->propertySchemas);
+        self::assertArrayHasKey('methodWithoutParameters', $schema->propertySchemas);
+        self::assertInstanceOf(LiteralStringSchema::class, $schema->propertySchemas['methodWithoutParameters']);
     }
 
     public function test_getSchema_skips_parameterized_methods_if_instructed(): void
@@ -142,6 +142,49 @@ final class IntegrationTest extends TestCase
         self::assertArrayNotHasKey('methodWithParameters', $schema->propertySchemas);
         self::assertArrayHasKey('methodWithoutParameters', $schema->propertySchemas);
         self::assertInstanceOf(LiteralStringSchema::class, $schema->propertySchemas['methodWithoutParameters']);
+    }
+
+    public function test_getSchema_skips_interface_methods_with_void_return_type(): void
+    {
+        $schema = Parser::getSchema(Fixture\SomeInterfaceWithVoidMethod::class);
+        self::assertInstanceOf(InterfaceSchema::class, $schema);
+        self::assertSame(['name'], array_keys($schema->propertySchemas));
+    }
+
+    public function test_getSchema_skips_static_interface_methods(): void
+    {
+        $schema = Parser::getSchema(Fixture\SomeInterfaceWithStaticMethod::class);
+        self::assertInstanceOf(InterfaceSchema::class, $schema);
+        self::assertSame(['name'], array_keys($schema->propertySchemas));
+    }
+
+    public function test_getSchema_skips_interface_methods_with_unmappable_return_types(): void
+    {
+        $schema = Parser::getSchema(Fixture\SomeInterfaceWithUnmappableReturnTypes::class);
+        self::assertInstanceOf(InterfaceSchema::class, $schema);
+        self::assertSame(['name'], array_keys($schema->propertySchemas));
+    }
+
+    public function test_getSchema_supports_interface_property_hooks(): void
+    {
+        $schema = Parser::getSchema(Fixture\SomeInterfaceWithPropertyHooks::class);
+        self::assertInstanceOf(InterfaceSchema::class, $schema);
+        // behavior method and #[Ignore]d property are skipped, the remaining `get` hooks become properties
+        self::assertSame(['givenName', 'familyName', 'age'], array_keys($schema->propertySchemas));
+        self::assertInstanceOf(StringSchema::class, $schema->propertySchemas['givenName']);
+        // a nullable property type is represented as an optional property
+        self::assertInstanceOf(OptionalSchema::class, $schema->propertySchemas['age']);
+        // #[Description] on a property hook is honored
+        self::assertSame('Custom description for "familyName"', $schema->overriddenPropertyDescription('familyName'));
+    }
+
+    public function test_getSchema_prefers_property_hook_over_method_of_the_same_name(): void
+    {
+        $schema = Parser::getSchema(Fixture\SomeInterfaceWithCollidingHookAndMethod::class);
+        self::assertInstanceOf(InterfaceSchema::class, $schema);
+        self::assertSame(['name'], array_keys($schema->propertySchemas));
+        // the hook (GivenName) wins over the colliding method (FamilyName)
+        self::assertSame('GivenName', $schema->propertySchemas['name']->getName());
     }
 
     public function test_getSchema_throws_if_shape_has_no_constructor(): void


### PR DESCRIPTION
Interface schemas previously treated every public method as a property and threw on methods with parameters (with #[Ignore] as the only escape) and crashed on `void` return types. This reworks interface property derivation:

* Properties are collected from PHP property hooks (with a `get` accessor) first, then from public, non-static, parameterless getter methods whose return type maps to a schema. A hook takes precedence over a same-named method.
* Any other method (parameterized, `void`, `static` or with an unmappable return type) is treated as behavior and silently skipped instead of throwing. This allows generating schemas for 3rd party interfaces that mix data accessors and behavior.
* #[Ignore] can now be placed on property hooks as well as methods.

#[Ignore] on parameterized methods is no longer required but stays supported. Requires PHP >= 8.4 for property hooks.