### PR TITLE
Dynamic schemas: create and extend schemas without a backing PHP class

### DIFF
--- a/README.md
+++ b/README.md
@@ -942,6 +942,63 @@ assert($normalized === $input);
 
 </details>
 
+## Dynamic schemas
+
+Usually schemas are derived from PHP classes via `Parser::getSchema()`. Sometimes you don't have a
+class for every type – for example when a schema is defined at runtime, loaded from configuration or
+assembled on the fly. `DynamicSchema` lets you build schemas that are **not** backed by a PHP class.
+
+Crucially, this does *not* introduce a separate schema type: a dynamic schema is the very same
+`StringSchema` / `ShapeSchema` / `ListSchema` / ... as a class-based one, so anything consuming a
+`Schema` (serialization, introspection, ...) treats both identically. The only difference is the
+instantiated *value*: a class-less schema instantiates into a generic, immutable container
+(`DynamicValue` / `DynamicRecord` / `DynamicList`) instead of a dedicated class.
+
+```php
+use Wwwision\Types\DynamicSchema;
+use Wwwision\Types\Options;
+
+$schema = DynamicSchema::shape('Coordinate', [
+    'latitude' => DynamicSchema::float('Latitude', minimum: -90, maximum: 90),
+    'longitude' => DynamicSchema::float('Longitude', minimum: -180, maximum: 180),
+]);
+
+$coordinate = $schema->instantiate(['latitude' => 51.5, 'longitude' => -0.1], Options::create());
+
+assert($coordinate['latitude']->value === 51.5);
+assert($schema->getName() === 'Coordinate');
+```
+
+Existing class-based schemas can be **extended** – adding or removing properties produces a
+class-less schema, while inherited properties keep their original schemas (so their values remain
+real, validated value objects):
+
+```php
+use Wwwision\Types\DynamicSchema;
+use Wwwision\Types\Options;
+
+#[StringBased(minLength: 1, maxLength: 200)]
+final class ProductName {
+    private function __construct(public readonly string $value) {}
+}
+final class Product {
+    public function __construct(public readonly ProductName $name) {}
+}
+
+$extended = DynamicSchema::extend(Parser::getSchema(Product::class), 'DiscountedProduct')
+    ->withProperty('discount', DynamicSchema::integer('Discount', minimum: 0, maximum: 100))
+    ->build();
+
+$discounted = $extended->instantiate(['name' => 'Widget', 'discount' => 20], Options::create());
+
+assert($discounted['name'] instanceof ProductName); // inherited: a real value object
+assert($discounted['discount']->value === 20);      // added: a dynamic value
+```
+
+> **Note**
+> Dynamic schemas currently cover the constructor-based types (string/integer/float/list/shape).
+> Enums and interfaces are resolution/dispatch based and remain class-backed.
+
 ## Integrations
 
 The declarative approach of this library allows for some interesting integrations.

--- a/README.md
+++ b/README.md
@@ -965,7 +965,7 @@ $schema = DynamicSchema::shape('Coordinate', [
 
 $coordinate = $schema->instantiate(['latitude' => 51.5, 'longitude' => -0.1], Options::create());
 
-assert($coordinate['latitude']->value === 51.5);
+assert($coordinate->latitude->value === 51.5);
 assert($schema->getName() === 'Coordinate');
 ```
 
@@ -991,8 +991,24 @@ $extended = DynamicSchema::extend(Parser::getSchema(Product::class), 'Discounted
 
 $discounted = $extended->instantiate(['name' => 'Widget', 'discount' => 20], Options::create());
 
-assert($discounted['name'] instanceof ProductName); // inherited: a real value object
-assert($discounted['discount']->value === 20);      // added: a dynamic value
+assert($discounted->name instanceof ProductName); // inherited: a real value object
+assert($discounted->discount->value === 20);      // added: a dynamic value
+```
+
+### Enum-like dynamic types
+
+There is no dynamic *enum* schema (enums resolve to pre-existing PHP cases, which requires a class).
+A class-less "one of a fixed set of values" type is easily expressed as a constrained string instead
+– it validates membership and yields a `DynamicValue`:
+
+```php
+use Wwwision\Types\DynamicSchema;
+use Wwwision\Types\Options;
+
+$title = DynamicSchema::string('Title', pattern: '^(MR|MRS|MS)$');
+
+assert($title->instantiate('MRS', Options::create())->value === 'MRS');
+// instantiating e.g. 'XX' would throw a CoerceException
 ```
 
 > **Note**

--- a/README.md
+++ b/README.md
@@ -995,6 +995,32 @@ assert($discounted->name instanceof ProductName); // inherited: a real value obj
 assert($discounted->discount->value === 20);      // added: a dynamic value
 ```
 
+### Introspecting dynamic values
+
+A dynamic value carries the `Schema` it was instantiated from (via `getSchema()`), and a
+`DynamicRecord` is iterable as `propertyName => value` – so integrations can map it to other type
+systems without a backing PHP class:
+
+```php
+use Wwwision\Types\DynamicSchema;
+use Wwwision\Types\Options;
+
+$schema = DynamicSchema::shape('Point', [
+    'x' => DynamicSchema::integer('X'),
+    'y' => DynamicSchema::integer('Y'),
+]);
+$point = $schema->instantiate(['x' => 1, 'y' => 2], Options::create());
+
+assert($point->getSchema()->getName() === 'Point');
+assert(array_keys($point->getSchema()->propertySchemas) === ['x', 'y']);
+
+$sum = 0;
+foreach ($point as $name => $value) {
+    $sum += $value->value;
+}
+assert($sum === 3);
+```
+
 ### Enum-like dynamic types
 
 There is no dynamic *enum* schema (enums resolve to pre-existing PHP cases, which requires a class).

--- a/docs/adr/0001-target-seam-for-dynamic-schemas.md
+++ b/docs/adr/0001-target-seam-for-dynamic-schemas.md
@@ -1,0 +1,33 @@
+# Dynamic and extensible schemas via a Target seam
+
+To support creating schemas that are not backed by a fixed PHP class (and extending existing
+class-based ones), each schema delegates its three class-coupled concerns — naming, instance
+checking, and the final "build the value" step — to a `Target`. `ClassTarget` reproduces the
+original reflection-based behavior; `DynamicTarget` builds a generic container
+(`DynamicValue`/`DynamicRecord`/`DynamicList`) instead. One set of schema classes serves both
+modes: there is **no** separate `DynamicShapeSchema`, so to consumers of a `Schema` a class-based
+and a dynamic schema are the same type with the same interface.
+
+## Considered Options
+
+- **Full class-agnostic rewrite** (pure-data schemas + registry + references + separate
+  parse/instantiate services) — prototyped on the parked `feature/v2-overhaul` branch and rejected:
+  it was a major, breaking change whose "purity / two-paths / stateful-services" benefits were means
+  we had assumed necessary, not actual goals. The dynamic-schema capability did not require it.
+- **Parallel `DynamicShapeSchema` twins** — rejected: introduces a second `Schema` implementation
+  per kind and duplicates coercion logic; consumers could (and would) end up distinguishing them.
+
+## Consequences
+
+- Non-breaking: the existing reflection path is unchanged (all prior tests pass untouched); this can
+  ship as a minor version.
+- The seam fits **constructor-based value types** — `StringSchema`, `IntegerSchema`, `FloatSchema`,
+  `ListSchema`, `ShapeSchema`. These are dynamically creatable via `DynamicSchema` and extensible via
+  `DynamicSchema::extend()`.
+- `OneOfSchema` holds no class and needs no Target. `EnumSchema` (value→case *resolution*) and
+  `InterfaceSchema` (discriminated *dispatch*) are deliberately left class-bound: their instantiation
+  is not construction, so forcing them through `Target::construct()` would distort the abstraction.
+  Making those dynamic is a separate, larger feature (dynamic interfaces in particular would
+  reintroduce a registry-like schema lookup).
+- The dynamic-ness surfaces only in the instantiated *value* (a container vs. a real object), never
+  in the schema's type or public interface.

--- a/src/DynamicSchema.php
+++ b/src/DynamicSchema.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Wwwision\Types;
 
-use Wwwision\Types\Schema\Dynamic\DynamicList;
-use Wwwision\Types\Schema\Dynamic\DynamicRecord;
-use Wwwision\Types\Schema\Dynamic\DynamicValue;
 use Wwwision\Types\Schema\Dynamic\ShapeExtender;
 use Wwwision\Types\Schema\FloatSchema;
 use Wwwision\Types\Schema\IntegerSchema;
@@ -16,8 +13,6 @@ use Wwwision\Types\Schema\ShapeSchema;
 use Wwwision\Types\Schema\StringSchema;
 use Wwwision\Types\Schema\StringTypeFormat;
 use Wwwision\Types\Schema\Target\DynamicTarget;
-
-use function reset;
 
 /**
  * Builds schemas that are NOT backed by a PHP class. The result is an ordinary {@see StringSchema} /
@@ -42,8 +37,7 @@ final class DynamicSchema
         array|null $examples = null,
         array|null $extensions = null,
     ): StringSchema {
-        $target = new DynamicTarget($name, static fn(array $arguments) => new DynamicValue($name, reset($arguments)));
-        return new StringSchema($target, $description, $minLength, $maxLength, $pattern, $format, $examples, $extensions);
+        return new StringSchema(DynamicTarget::scalar($name), $description, $minLength, $maxLength, $pattern, $format, $examples, $extensions);
     }
 
     /**
@@ -58,8 +52,7 @@ final class DynamicSchema
         array|null $examples = null,
         array|null $extensions = null,
     ): IntegerSchema {
-        $target = new DynamicTarget($name, static fn(array $arguments) => new DynamicValue($name, reset($arguments)));
-        return new IntegerSchema($target, $description, $minimum, $maximum, $examples, $extensions);
+        return new IntegerSchema(DynamicTarget::scalar($name), $description, $minimum, $maximum, $examples, $extensions);
     }
 
     /**
@@ -74,8 +67,7 @@ final class DynamicSchema
         array|null $examples = null,
         array|null $extensions = null,
     ): FloatSchema {
-        $target = new DynamicTarget($name, static fn(array $arguments) => new DynamicValue($name, reset($arguments)));
-        return new FloatSchema($target, $description, $minimum, $maximum, $examples, $extensions);
+        return new FloatSchema(DynamicTarget::scalar($name), $description, $minimum, $maximum, $examples, $extensions);
     }
 
     /**
@@ -89,8 +81,7 @@ final class DynamicSchema
         string|null $description = null,
         array|null $extensions = null,
     ): ListSchema {
-        $target = new DynamicTarget($name, static fn(array $arguments) => new DynamicList($name, reset($arguments)));
-        return new ListSchema($target, $description, $itemSchema, $minCount, $maxCount, $extensions);
+        return new ListSchema(DynamicTarget::list($name), $description, $itemSchema, $minCount, $maxCount, $extensions);
     }
 
     /**
@@ -98,8 +89,7 @@ final class DynamicSchema
      */
     public static function shape(string $name, array $properties, string|null $description = null): ShapeSchema
     {
-        $target = new DynamicTarget($name, static fn(array $arguments) => new DynamicRecord($name, $arguments));
-        return new ShapeSchema($target, $description, $properties, [], []);
+        return new ShapeSchema(DynamicTarget::record($name), $description, $properties, [], []);
     }
 
     /**

--- a/src/DynamicSchema.php
+++ b/src/DynamicSchema.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Wwwision\Types;
 
+use Wwwision\Types\Schema\Dynamic\DynamicList;
 use Wwwision\Types\Schema\Dynamic\DynamicRecord;
 use Wwwision\Types\Schema\Dynamic\DynamicValue;
 use Wwwision\Types\Schema\Dynamic\ShapeExtender;
+use Wwwision\Types\Schema\FloatSchema;
+use Wwwision\Types\Schema\IntegerSchema;
+use Wwwision\Types\Schema\ListSchema;
 use Wwwision\Types\Schema\Schema;
 use Wwwision\Types\Schema\ShapeSchema;
 use Wwwision\Types\Schema\StringSchema;
@@ -40,6 +44,53 @@ final class DynamicSchema
     ): StringSchema {
         $target = new DynamicTarget($name, static fn(array $arguments) => new DynamicValue($name, reset($arguments)));
         return new StringSchema($target, $description, $minLength, $maxLength, $pattern, $format, $examples, $extensions);
+    }
+
+    /**
+     * @param array<int>|null $examples
+     * @param array<string, mixed>|null $extensions
+     */
+    public static function integer(
+        string $name,
+        string|null $description = null,
+        int|null $minimum = null,
+        int|null $maximum = null,
+        array|null $examples = null,
+        array|null $extensions = null,
+    ): IntegerSchema {
+        $target = new DynamicTarget($name, static fn(array $arguments) => new DynamicValue($name, reset($arguments)));
+        return new IntegerSchema($target, $description, $minimum, $maximum, $examples, $extensions);
+    }
+
+    /**
+     * @param array<float|int>|null $examples
+     * @param array<string, mixed>|null $extensions
+     */
+    public static function float(
+        string $name,
+        string|null $description = null,
+        float|int|null $minimum = null,
+        float|int|null $maximum = null,
+        array|null $examples = null,
+        array|null $extensions = null,
+    ): FloatSchema {
+        $target = new DynamicTarget($name, static fn(array $arguments) => new DynamicValue($name, reset($arguments)));
+        return new FloatSchema($target, $description, $minimum, $maximum, $examples, $extensions);
+    }
+
+    /**
+     * @param array<string, mixed>|null $extensions
+     */
+    public static function list(
+        string $name,
+        Schema $itemSchema,
+        int|null $minCount = null,
+        int|null $maxCount = null,
+        string|null $description = null,
+        array|null $extensions = null,
+    ): ListSchema {
+        $target = new DynamicTarget($name, static fn(array $arguments) => new DynamicList($name, reset($arguments)));
+        return new ListSchema($target, $description, $itemSchema, $minCount, $maxCount, $extensions);
     }
 
     /**

--- a/src/DynamicSchema.php
+++ b/src/DynamicSchema.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\Types;
+
+use Wwwision\Types\Schema\Dynamic\DynamicRecord;
+use Wwwision\Types\Schema\Dynamic\DynamicValue;
+use Wwwision\Types\Schema\Dynamic\ShapeExtender;
+use Wwwision\Types\Schema\Schema;
+use Wwwision\Types\Schema\ShapeSchema;
+use Wwwision\Types\Schema\StringSchema;
+use Wwwision\Types\Schema\StringTypeFormat;
+use Wwwision\Types\Schema\Target\DynamicTarget;
+
+use function reset;
+
+/**
+ * Builds schemas that are NOT backed by a PHP class. The result is an ordinary {@see StringSchema} /
+ * {@see ShapeSchema} (no separate "dynamic" schema type) – only the injected
+ * {@see DynamicTarget} differs, so 3rd-party consumers see no difference.
+ */
+final class DynamicSchema
+{
+    private function __construct() {}
+
+    /**
+     * @param array<string>|null $examples
+     * @param array<string, mixed>|null $extensions
+     */
+    public static function string(
+        string $name,
+        string|null $description = null,
+        int|null $minLength = null,
+        int|null $maxLength = null,
+        string|null $pattern = null,
+        StringTypeFormat|null $format = null,
+        array|null $examples = null,
+        array|null $extensions = null,
+    ): StringSchema {
+        $target = new DynamicTarget($name, static fn(array $arguments) => new DynamicValue($name, reset($arguments)));
+        return new StringSchema($target, $description, $minLength, $maxLength, $pattern, $format, $examples, $extensions);
+    }
+
+    /**
+     * @param array<non-empty-string, Schema> $properties
+     */
+    public static function shape(string $name, array $properties, string|null $description = null): ShapeSchema
+    {
+        $target = new DynamicTarget($name, static fn(array $arguments) => new DynamicRecord($name, $arguments));
+        return new ShapeSchema($target, $description, $properties, [], []);
+    }
+
+    /**
+     * Starts extending an existing (class-based or dynamic) shape schema. Adding/removing properties
+     * produces a binding-less {@see ShapeSchema} that instantiates to a {@see DynamicRecord}; inherited
+     * properties keep their original (e.g. class-based) schemas, so their values stay real VOs.
+     */
+    public static function extend(ShapeSchema $base, string $name): ShapeExtender
+    {
+        return new ShapeExtender($name, $base);
+    }
+}

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -135,10 +135,10 @@ final class Parser
             $baseTypeAttribute = $baseTypeAttributes[0]->newInstance();
             return match ($baseTypeAttribute::class) {
                 StringBased::class => new StringSchema(new ClassTarget($reflectionClass), self::getDescription($reflectionClass), $baseTypeAttribute->minLength, $baseTypeAttribute->maxLength, $baseTypeAttribute->pattern, $baseTypeAttribute->format, $baseTypeAttribute->examples, $baseTypeAttribute->extensions),
-                IntegerBased::class => new IntegerSchema($reflectionClass, self::getDescription($reflectionClass), $baseTypeAttribute->minimum, $baseTypeAttribute->maximum, $baseTypeAttribute->examples, $baseTypeAttribute->extensions),
-                FloatBased::class => new FloatSchema($reflectionClass, self::getDescription($reflectionClass), $baseTypeAttribute->minimum, $baseTypeAttribute->maximum, $baseTypeAttribute->examples, $baseTypeAttribute->extensions),
+                IntegerBased::class => new IntegerSchema(new ClassTarget($reflectionClass), self::getDescription($reflectionClass), $baseTypeAttribute->minimum, $baseTypeAttribute->maximum, $baseTypeAttribute->examples, $baseTypeAttribute->extensions),
+                FloatBased::class => new FloatSchema(new ClassTarget($reflectionClass), self::getDescription($reflectionClass), $baseTypeAttribute->minimum, $baseTypeAttribute->maximum, $baseTypeAttribute->examples, $baseTypeAttribute->extensions),
                 ListBased::class => new ListSchema(
-                    $reflectionClass,
+                    new ClassTarget($reflectionClass),
                     self::getDescription($reflectionClass),
                     self::getSchema($baseTypeAttribute->itemClassName),
                     $baseTypeAttribute->minCount,

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -44,6 +44,7 @@ use Wwwision\Types\Schema\OptionalSchema;
 use Wwwision\Types\Schema\Schema;
 use Wwwision\Types\Schema\ShapeSchema;
 use Wwwision\Types\Schema\StringSchema;
+use Wwwision\Types\Schema\Target\ClassTarget;
 
 use function class_exists;
 use function get_debug_type;
@@ -133,7 +134,7 @@ final class Parser
             Assert::count($baseTypeAttributes, 1, 'Expected exactly %d BaseType attribute for class "' . $reflectionClass->getName() . '", got %d');
             $baseTypeAttribute = $baseTypeAttributes[0]->newInstance();
             return match ($baseTypeAttribute::class) {
-                StringBased::class => new StringSchema($reflectionClass, self::getDescription($reflectionClass), $baseTypeAttribute->minLength, $baseTypeAttribute->maxLength, $baseTypeAttribute->pattern, $baseTypeAttribute->format, $baseTypeAttribute->examples, $baseTypeAttribute->extensions),
+                StringBased::class => new StringSchema(new ClassTarget($reflectionClass), self::getDescription($reflectionClass), $baseTypeAttribute->minLength, $baseTypeAttribute->maxLength, $baseTypeAttribute->pattern, $baseTypeAttribute->format, $baseTypeAttribute->examples, $baseTypeAttribute->extensions),
                 IntegerBased::class => new IntegerSchema($reflectionClass, self::getDescription($reflectionClass), $baseTypeAttribute->minimum, $baseTypeAttribute->maximum, $baseTypeAttribute->examples, $baseTypeAttribute->extensions),
                 FloatBased::class => new FloatSchema($reflectionClass, self::getDescription($reflectionClass), $baseTypeAttribute->minimum, $baseTypeAttribute->maximum, $baseTypeAttribute->examples, $baseTypeAttribute->extensions),
                 ListBased::class => new ListSchema(
@@ -221,7 +222,7 @@ final class Parser
             }
             $propertySchemas[$propertyName] = $propertySchema;
         }
-        return new ShapeSchema($reflectionClass, self::getDescription($reflectionClass), $propertySchemas, $overriddenPropertyDescriptions, $propertyDiscriminators);
+        return new ShapeSchema(new ClassTarget($reflectionClass), self::getDescription($reflectionClass), $propertySchemas, $overriddenPropertyDescriptions, $propertyDiscriminators);
     }
 
     /**

--- a/src/Schema/Dynamic/DynamicInstance.php
+++ b/src/Schema/Dynamic/DynamicInstance.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\Types\Schema\Dynamic;
+
+/**
+ * Marker for values produced by a {@see \Wwwision\Types\Schema\Target\DynamicTarget}. Carries the
+ * schema's name so a dynamic value remains distinguishable at runtime even though `instanceof`
+ * cannot tell two dynamic types apart.
+ */
+interface DynamicInstance
+{
+    public string $typeName { get; }
+}

--- a/src/Schema/Dynamic/DynamicInstance.php
+++ b/src/Schema/Dynamic/DynamicInstance.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace Wwwision\Types\Schema\Dynamic;
 
+use Wwwision\Types\Schema\Schema;
+
 /**
- * Marker for values produced by a {@see \Wwwision\Types\Schema\Target\DynamicTarget}. Carries the
- * schema's name so a dynamic value remains distinguishable at runtime even though `instanceof`
- * cannot tell two dynamic types apart.
+ * Marker for values produced by a {@see \Wwwision\Types\Schema\Target\DynamicTarget}. Exposes the
+ * {@see Schema} it was instantiated from, so consumers (e.g. integrations) can introspect the type –
+ * its name, properties, item type, constraints, ... – even though no dedicated PHP class exists.
+ *
+ * Accessed via a method (rather than a property) so that {@see DynamicRecord}'s magic property space
+ * stays free for actual record properties of any name.
  */
 interface DynamicInstance
 {
-    public string $typeName { get; }
+    public function getSchema(): Schema;
 }

--- a/src/Schema/Dynamic/DynamicList.php
+++ b/src/Schema/Dynamic/DynamicList.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\Types\Schema\Dynamic;
+
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+use JsonSerializable;
+use Traversable;
+
+/**
+ * Immutable container a binding-less list schema instantiates into. Iterable and countable; its
+ * items may be real value objects or other dynamic values.
+ *
+ * @implements IteratorAggregate<int|string, mixed>
+ */
+final class DynamicList implements DynamicInstance, JsonSerializable, IteratorAggregate, Countable
+{
+    /**
+     * @param array<int|string, mixed> $items
+     */
+    public function __construct(
+        public readonly string $typeName,
+        private readonly array $items,
+    ) {}
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->items);
+    }
+
+    public function count(): int
+    {
+        return count($this->items);
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->items;
+    }
+}

--- a/src/Schema/Dynamic/DynamicList.php
+++ b/src/Schema/Dynamic/DynamicList.php
@@ -9,10 +9,12 @@ use Countable;
 use IteratorAggregate;
 use JsonSerializable;
 use Traversable;
+use Wwwision\Types\Schema\ListSchema;
 
 /**
- * Immutable container a binding-less list schema instantiates into. Iterable and countable; its
- * items may be real value objects or other dynamic values.
+ * Immutable container a binding-less list schema instantiates into. Iterable and countable; exposes
+ * its {@see ListSchema} (and thereby its item type). Items may be real value objects or other
+ * dynamic values.
  *
  * @implements IteratorAggregate<int|string, mixed>
  */
@@ -22,9 +24,14 @@ final class DynamicList implements DynamicInstance, JsonSerializable, IteratorAg
      * @param array<int|string, mixed> $items
      */
     public function __construct(
-        public readonly string $typeName,
+        private readonly ListSchema $schema,
         private readonly array $items,
     ) {}
+
+    public function getSchema(): ListSchema
+    {
+        return $this->schema;
+    }
 
     public function getIterator(): Traversable
     {

--- a/src/Schema/Dynamic/DynamicRecord.php
+++ b/src/Schema/Dynamic/DynamicRecord.php
@@ -51,6 +51,16 @@ final class DynamicRecord implements DynamicInstance, JsonSerializable, Iterator
         return $this->has($name);
     }
 
+    public function __set(string $name, mixed $value): never
+    {
+        throw new LogicException(sprintf('Dynamic record "%s" is immutable', $this->schema->getName()), 1700000053);
+    }
+
+    public function __unset(string $name): never
+    {
+        throw new LogicException(sprintf('Dynamic record "%s" is immutable', $this->schema->getName()), 1700000054);
+    }
+
     public function get(string $name): mixed
     {
         if (!array_key_exists($name, $this->properties)) {

--- a/src/Schema/Dynamic/DynamicRecord.php
+++ b/src/Schema/Dynamic/DynamicRecord.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Wwwision\Types\Schema\Dynamic;
 
-use ArrayAccess;
 use JsonSerializable;
 use LogicException;
 
@@ -12,13 +11,12 @@ use function array_key_exists;
 use function sprintf;
 
 /**
- * Immutable container a binding-less shape schema instantiates into. Array-backed with magic read
- * access; its property values may themselves be real value objects (when inherited from an extended
- * class-based schema) or other dynamic values.
- *
- * @implements ArrayAccess<string, mixed>
+ * Immutable container a binding-less shape schema instantiates into. Properties are read with the
+ * natural object-accessor syntax (`$record->propertyName`) via {@see __get}; for statically analyzed
+ * code use the explicit {@see get()} / {@see has()}. Property values may themselves be real value
+ * objects (when inherited from an extended class-based schema) or other dynamic values.
  */
-final class DynamicRecord implements DynamicInstance, JsonSerializable, ArrayAccess
+final class DynamicRecord implements DynamicInstance, JsonSerializable
 {
     /**
      * @param array<string, mixed> $properties
@@ -30,35 +28,25 @@ final class DynamicRecord implements DynamicInstance, JsonSerializable, ArrayAcc
 
     public function __get(string $name): mixed
     {
+        return $this->get($name);
+    }
+
+    public function __isset(string $name): bool
+    {
+        return $this->has($name);
+    }
+
+    public function get(string $name): mixed
+    {
         if (!array_key_exists($name, $this->properties)) {
             throw new LogicException(sprintf('Property "%s" does not exist on dynamic record "%s"', $name, $this->typeName), 1700000050);
         }
         return $this->properties[$name];
     }
 
-    public function __isset(string $name): bool
+    public function has(string $name): bool
     {
         return array_key_exists($name, $this->properties);
-    }
-
-    public function offsetExists(mixed $offset): bool
-    {
-        return array_key_exists($offset, $this->properties);
-    }
-
-    public function offsetGet(mixed $offset): mixed
-    {
-        return $this->__get($offset);
-    }
-
-    public function offsetSet(mixed $offset, mixed $value): never
-    {
-        throw new LogicException('Dynamic records are immutable', 1700000051);
-    }
-
-    public function offsetUnset(mixed $offset): never
-    {
-        throw new LogicException('Dynamic records are immutable', 1700000052);
     }
 
     /**

--- a/src/Schema/Dynamic/DynamicRecord.php
+++ b/src/Schema/Dynamic/DynamicRecord.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\Types\Schema\Dynamic;
+
+use ArrayAccess;
+use JsonSerializable;
+use LogicException;
+
+use function array_key_exists;
+use function sprintf;
+
+/**
+ * Immutable container a binding-less shape schema instantiates into. Array-backed with magic read
+ * access; its property values may themselves be real value objects (when inherited from an extended
+ * class-based schema) or other dynamic values.
+ *
+ * @implements ArrayAccess<string, mixed>
+ */
+final class DynamicRecord implements DynamicInstance, JsonSerializable, ArrayAccess
+{
+    /**
+     * @param array<string, mixed> $properties
+     */
+    public function __construct(
+        public readonly string $typeName,
+        private readonly array $properties,
+    ) {}
+
+    public function __get(string $name): mixed
+    {
+        if (!array_key_exists($name, $this->properties)) {
+            throw new LogicException(sprintf('Property "%s" does not exist on dynamic record "%s"', $name, $this->typeName), 1700000050);
+        }
+        return $this->properties[$name];
+    }
+
+    public function __isset(string $name): bool
+    {
+        return array_key_exists($name, $this->properties);
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return array_key_exists($offset, $this->properties);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->__get($offset);
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): never
+    {
+        throw new LogicException('Dynamic records are immutable', 1700000051);
+    }
+
+    public function offsetUnset(mixed $offset): never
+    {
+        throw new LogicException('Dynamic records are immutable', 1700000052);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->properties;
+    }
+}

--- a/src/Schema/Dynamic/DynamicRecord.php
+++ b/src/Schema/Dynamic/DynamicRecord.php
@@ -53,18 +53,18 @@ final class DynamicRecord implements DynamicInstance, JsonSerializable, Iterator
 
     public function __set(string $name, mixed $value): never
     {
-        throw new LogicException(sprintf('Dynamic record "%s" is immutable', $this->schema->getName()), 1700000053);
+        throw new LogicException(sprintf('Dynamic record "%s" is immutable', $this->schema->getName()), 1782465458);
     }
 
     public function __unset(string $name): never
     {
-        throw new LogicException(sprintf('Dynamic record "%s" is immutable', $this->schema->getName()), 1700000054);
+        throw new LogicException(sprintf('Dynamic record "%s" is immutable', $this->schema->getName()), 1782465459);
     }
 
     public function get(string $name): mixed
     {
         if (!array_key_exists($name, $this->properties)) {
-            throw new LogicException(sprintf('Property "%s" does not exist on dynamic record "%s"', $name, $this->schema->getName()), 1700000050);
+            throw new LogicException(sprintf('Property "%s" does not exist on dynamic record "%s"', $name, $this->schema->getName()), 1782465457);
         }
         return $this->properties[$name];
     }

--- a/src/Schema/Dynamic/DynamicRecord.php
+++ b/src/Schema/Dynamic/DynamicRecord.php
@@ -4,27 +4,42 @@ declare(strict_types=1);
 
 namespace Wwwision\Types\Schema\Dynamic;
 
+use ArrayIterator;
+use IteratorAggregate;
 use JsonSerializable;
 use LogicException;
+use Traversable;
+use Wwwision\Types\Schema\ShapeSchema;
 
 use function array_key_exists;
+use function array_keys;
 use function sprintf;
 
 /**
  * Immutable container a binding-less shape schema instantiates into. Properties are read with the
  * natural object-accessor syntax (`$record->propertyName`) via {@see __get}; for statically analyzed
- * code use the explicit {@see get()} / {@see has()}. Property values may themselves be real value
- * objects (when inherited from an extended class-based schema) or other dynamic values.
+ * code use {@see get()} / {@see has()}. Iterable as `propertyName => value`, and exposes its
+ * {@see ShapeSchema} so consumers can introspect property names, types and descriptions.
+ *
+ * Property values may themselves be real value objects (inherited from an extended class-based
+ * schema) or other dynamic values.
+ *
+ * @implements IteratorAggregate<string, mixed>
  */
-final class DynamicRecord implements DynamicInstance, JsonSerializable
+final class DynamicRecord implements DynamicInstance, JsonSerializable, IteratorAggregate
 {
     /**
      * @param array<string, mixed> $properties
      */
     public function __construct(
-        public readonly string $typeName,
+        private readonly ShapeSchema $schema,
         private readonly array $properties,
     ) {}
+
+    public function getSchema(): ShapeSchema
+    {
+        return $this->schema;
+    }
 
     public function __get(string $name): mixed
     {
@@ -39,7 +54,7 @@ final class DynamicRecord implements DynamicInstance, JsonSerializable
     public function get(string $name): mixed
     {
         if (!array_key_exists($name, $this->properties)) {
-            throw new LogicException(sprintf('Property "%s" does not exist on dynamic record "%s"', $name, $this->typeName), 1700000050);
+            throw new LogicException(sprintf('Property "%s" does not exist on dynamic record "%s"', $name, $this->schema->getName()), 1700000050);
         }
         return $this->properties[$name];
     }
@@ -47,6 +62,19 @@ final class DynamicRecord implements DynamicInstance, JsonSerializable
     public function has(string $name): bool
     {
         return array_key_exists($name, $this->properties);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function propertyNames(): array
+    {
+        return array_keys($this->properties);
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->properties);
     }
 
     /**

--- a/src/Schema/Dynamic/DynamicValue.php
+++ b/src/Schema/Dynamic/DynamicValue.php
@@ -6,16 +6,22 @@ namespace Wwwision\Types\Schema\Dynamic;
 
 use JsonSerializable;
 use Stringable;
+use Wwwision\Types\Schema\Schema;
 
 /**
- * Immutable container a binding-less scalar schema (string/integer/float/...) instantiates into.
+ * Immutable container a binding-less scalar schema (string/integer/float) instantiates into.
  */
 final class DynamicValue implements DynamicInstance, JsonSerializable, Stringable
 {
     public function __construct(
-        public readonly string $typeName,
+        private readonly Schema $schema,
         public readonly string|int|float|bool $value,
     ) {}
+
+    public function getSchema(): Schema
+    {
+        return $this->schema;
+    }
 
     public function jsonSerialize(): string|int|float|bool
     {

--- a/src/Schema/Dynamic/DynamicValue.php
+++ b/src/Schema/Dynamic/DynamicValue.php
@@ -6,7 +6,9 @@ namespace Wwwision\Types\Schema\Dynamic;
 
 use JsonSerializable;
 use Stringable;
-use Wwwision\Types\Schema\Schema;
+use Wwwision\Types\Schema\FloatSchema;
+use Wwwision\Types\Schema\IntegerSchema;
+use Wwwision\Types\Schema\StringSchema;
 
 /**
  * Immutable container a binding-less scalar schema (string/integer/float) instantiates into.
@@ -14,11 +16,11 @@ use Wwwision\Types\Schema\Schema;
 final class DynamicValue implements DynamicInstance, JsonSerializable, Stringable
 {
     public function __construct(
-        private readonly Schema $schema,
+        private readonly StringSchema|IntegerSchema|FloatSchema $schema,
         public readonly string|int|float|bool $value,
     ) {}
 
-    public function getSchema(): Schema
+    public function getSchema(): StringSchema|IntegerSchema|FloatSchema
     {
         return $this->schema;
     }

--- a/src/Schema/Dynamic/DynamicValue.php
+++ b/src/Schema/Dynamic/DynamicValue.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\Types\Schema\Dynamic;
+
+use JsonSerializable;
+use Stringable;
+
+/**
+ * Immutable container a binding-less scalar schema (string/integer/float/...) instantiates into.
+ */
+final class DynamicValue implements DynamicInstance, JsonSerializable, Stringable
+{
+    public function __construct(
+        public readonly string $typeName,
+        public readonly string|int|float|bool $value,
+    ) {}
+
+    public function jsonSerialize(): string|int|float|bool
+    {
+        return $this->value;
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->value;
+    }
+}

--- a/src/Schema/Dynamic/ShapeExtender.php
+++ b/src/Schema/Dynamic/ShapeExtender.php
@@ -59,8 +59,6 @@ final class ShapeExtender
 
     public function build(): ShapeSchema
     {
-        $name = $this->name;
-        $target = new DynamicTarget($name, static fn(array $arguments) => new DynamicRecord($name, $arguments));
-        return new ShapeSchema($target, $this->description, $this->propertySchemas, [], []);
+        return new ShapeSchema(DynamicTarget::record($this->name), $this->description, $this->propertySchemas, [], []);
     }
 }

--- a/src/Schema/Dynamic/ShapeExtender.php
+++ b/src/Schema/Dynamic/ShapeExtender.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\Types\Schema\Dynamic;
+
+use Wwwision\Types\Schema\Schema;
+use Wwwision\Types\Schema\ShapeSchema;
+use Wwwision\Types\Schema\Target\DynamicTarget;
+
+/**
+ * Immutable builder for extending a {@see ShapeSchema}. Reads the base schema's public
+ * `propertySchemas`, lets you add/remove/override properties, and builds a binding-less
+ * {@see ShapeSchema} (instantiating to a {@see DynamicRecord}).
+ */
+final class ShapeExtender
+{
+    /**
+     * @var array<non-empty-string, Schema>
+     */
+    private array $propertySchemas;
+
+    private string|null $description;
+
+    public function __construct(
+        private readonly string $name,
+        ShapeSchema $base,
+    ) {
+        $this->propertySchemas = $base->propertySchemas;
+        $this->description = $base->getDescription();
+    }
+
+    /**
+     * @param non-empty-string $name
+     */
+    public function withProperty(string $name, Schema $schema): self
+    {
+        $clone = clone $this;
+        $clone->propertySchemas[$name] = $schema;
+        return $clone;
+    }
+
+    /**
+     * @param non-empty-string $name
+     */
+    public function withoutProperty(string $name): self
+    {
+        $clone = clone $this;
+        unset($clone->propertySchemas[$name]);
+        return $clone;
+    }
+
+    public function withDescription(string|null $description): self
+    {
+        $clone = clone $this;
+        $clone->description = $description;
+        return $clone;
+    }
+
+    public function build(): ShapeSchema
+    {
+        $name = $this->name;
+        $target = new DynamicTarget($name, static fn(array $arguments) => new DynamicRecord($name, $arguments));
+        return new ShapeSchema($target, $this->description, $this->propertySchemas, [], []);
+    }
+}

--- a/src/Schema/FloatSchema.php
+++ b/src/Schema/FloatSchema.php
@@ -4,31 +4,24 @@ declare(strict_types=1);
 
 namespace Wwwision\Types\Schema;
 
-use ReflectionClass;
-use ReflectionException;
-use ReflectionMethod;
-use RuntimeException;
 use Stringable;
-use Webmozart\Assert\Assert;
 use Wwwision\Types\Exception\CoerceException;
 use Wwwision\Types\Exception\Issues\Issues;
-
 use Wwwision\Types\Options;
+use Wwwision\Types\Schema\Target\Target;
 
 use function is_float;
 use function is_int;
 use function is_string;
-use function sprintf;
 
 final class FloatSchema implements Schema
 {
     /**
-     * @param ReflectionClass<object> $reflectionClass
      * @param array<float|int>|null $examples
      * @param array<string, mixed>|null $extensions
      */
     public function __construct(
-        private readonly ReflectionClass $reflectionClass,
+        private readonly Target $target,
         public readonly string|null $description,
         public readonly float|int|null $minimum = null,
         public readonly float|int|null $maximum = null,
@@ -43,7 +36,7 @@ final class FloatSchema implements Schema
 
     public function getName(): string
     {
-        return $this->reflectionClass->getShortName();
+        return $this->target->name();
     }
 
     public function getDescription(): string|null
@@ -51,29 +44,18 @@ final class FloatSchema implements Schema
         return $this->description;
     }
 
-    /** @phpstan-assert-if-true object $value */
     public function isInstance(mixed $value): bool
     {
-        return is_object($value) && $this->reflectionClass->isInstance($value);
+        return $this->target->isInstance($value);
     }
 
-    public function instantiate(mixed $value, Options $options): object
+    public function instantiate(mixed $value, Options $options): mixed
     {
-        if ($this->isInstance($value)) {
+        if ($this->target->isInstance($value)) {
             return $value;
         }
-        $intValue = $this->coerce($value);
-        $constructor = $this->reflectionClass->getConstructor();
-        Assert::isInstanceOf($constructor, ReflectionMethod::class, sprintf('Missing constructor in class "%s"', $this->reflectionClass->getName()));
-        try {
-            $instance = $this->reflectionClass->newInstanceWithoutConstructor();
-            $constructor->invoke($instance, $intValue);
-            // @codeCoverageIgnoreStart
-        } catch (ReflectionException $e) {
-            throw new RuntimeException(sprintf('Failed to instantiate "%s": %s', $this->getName(), $e->getMessage()), 1688570532, $e);
-        }
-        // @codeCoverageIgnoreEnd
-        return $instance;
+        $floatValue = $this->coerce($value);
+        return $this->target->construct([$floatValue]);
     }
 
     private function coerce(mixed $value): float

--- a/src/Schema/FloatSchema.php
+++ b/src/Schema/FloatSchema.php
@@ -55,7 +55,7 @@ final class FloatSchema implements Schema
             return $value;
         }
         $floatValue = $this->coerce($value);
-        return $this->target->construct([$floatValue]);
+        return $this->target->construct($this, [$floatValue]);
     }
 
     private function coerce(mixed $value): float

--- a/src/Schema/IntegerSchema.php
+++ b/src/Schema/IntegerSchema.php
@@ -55,7 +55,7 @@ final class IntegerSchema implements Schema
             return $value;
         }
         $intValue = $this->coerce($value);
-        return $this->target->construct([$intValue]);
+        return $this->target->construct($this, [$intValue]);
     }
 
     private function coerce(mixed $value): int

--- a/src/Schema/IntegerSchema.php
+++ b/src/Schema/IntegerSchema.php
@@ -4,31 +4,24 @@ declare(strict_types=1);
 
 namespace Wwwision\Types\Schema;
 
-use ReflectionClass;
-use ReflectionException;
-use ReflectionMethod;
-use RuntimeException;
 use Stringable;
-use Webmozart\Assert\Assert;
 use Wwwision\Types\Exception\CoerceException;
 use Wwwision\Types\Exception\Issues\Issues;
-
 use Wwwision\Types\Options;
+use Wwwision\Types\Schema\Target\Target;
 
 use function is_float;
 use function is_int;
 use function is_string;
-use function sprintf;
 
 final class IntegerSchema implements Schema
 {
     /**
-     * @param ReflectionClass<object> $reflectionClass
      * @param array<int>|null $examples
      * @param array<string, mixed>|null $extensions
      */
     public function __construct(
-        private readonly ReflectionClass $reflectionClass,
+        private readonly Target $target,
         public readonly string|null $description,
         public readonly int|null $minimum = null,
         public readonly int|null $maximum = null,
@@ -43,7 +36,7 @@ final class IntegerSchema implements Schema
 
     public function getName(): string
     {
-        return $this->reflectionClass->getShortName();
+        return $this->target->name();
     }
 
     public function getDescription(): string|null
@@ -51,29 +44,18 @@ final class IntegerSchema implements Schema
         return $this->description;
     }
 
-    /** @phpstan-assert-if-true object $value */
     public function isInstance(mixed $value): bool
     {
-        return is_object($value) && $this->reflectionClass->isInstance($value);
+        return $this->target->isInstance($value);
     }
 
-    public function instantiate(mixed $value, Options $options): object
+    public function instantiate(mixed $value, Options $options): mixed
     {
-        if ($this->isInstance($value)) {
+        if ($this->target->isInstance($value)) {
             return $value;
         }
         $intValue = $this->coerce($value);
-        $constructor = $this->reflectionClass->getConstructor();
-        Assert::isInstanceOf($constructor, ReflectionMethod::class, sprintf('Missing constructor in class "%s"', $this->reflectionClass->getName()));
-        try {
-            $instance = $this->reflectionClass->newInstanceWithoutConstructor();
-            $constructor->invoke($instance, $intValue);
-            // @codeCoverageIgnoreStart
-        } catch (ReflectionException $e) {
-            throw new RuntimeException(sprintf('Failed to instantiate "%s": %s', $this->getName(), $e->getMessage()), 1688570532, $e);
-        }
-        // @codeCoverageIgnoreEnd
-        return $instance;
+        return $this->target->construct([$intValue]);
     }
 
     private function coerce(mixed $value): int

--- a/src/Schema/ListSchema.php
+++ b/src/Schema/ListSchema.php
@@ -4,27 +4,20 @@ declare(strict_types=1);
 
 namespace Wwwision\Types\Schema;
 
-use ReflectionClass;
-use ReflectionException;
-use ReflectionMethod;
-use RuntimeException;
-use Webmozart\Assert\Assert;
 use Wwwision\Types\Exception\CoerceException;
 use Wwwision\Types\Exception\Issues\Issues;
-
 use Wwwision\Types\Options;
+use Wwwision\Types\Schema\Target\Target;
 
 use function is_iterable;
-use function sprintf;
 
 final class ListSchema implements Schema
 {
     /**
-     * @param ReflectionClass<object> $reflectionClass
      * @param array<string, mixed>|null $extensions
      */
     public function __construct(
-        private readonly ReflectionClass $reflectionClass,
+        private readonly Target $target,
         public readonly string|null $description,
         public readonly Schema $itemSchema,
         public readonly int|null $minCount = null,
@@ -39,7 +32,7 @@ final class ListSchema implements Schema
 
     public function getName(): string
     {
-        return $this->reflectionClass->getShortName();
+        return $this->target->name();
     }
 
     public function getDescription(): string|null
@@ -47,29 +40,18 @@ final class ListSchema implements Schema
         return $this->description;
     }
 
-    /** @phpstan-assert-if-true object $value */
     public function isInstance(mixed $value): bool
     {
-        return is_object($value) && $this->reflectionClass->isInstance($value);
+        return $this->target->isInstance($value);
     }
 
-    public function instantiate(mixed $value, Options $options): object
+    public function instantiate(mixed $value, Options $options): mixed
     {
-        if ($this->isInstance($value)) {
+        if ($this->target->isInstance($value)) {
             return $value;
         }
         $arrayValue = $this->coerce($value, $options);
-        $constructor = $this->reflectionClass->getConstructor();
-        Assert::isInstanceOf($constructor, ReflectionMethod::class, sprintf('Missing constructor in class "%s"', $this->reflectionClass->getName()));
-        try {
-            $instance = $this->reflectionClass->newInstanceWithoutConstructor();
-            $constructor->invoke($instance, $arrayValue);
-            // @codeCoverageIgnoreStart
-        } catch (ReflectionException $e) {
-            throw new RuntimeException(sprintf('Failed to instantiate "%s": %s', $this->getName(), $e->getMessage()), 1688570532, $e);
-        }
-        // @codeCoverageIgnoreEnd
-        return $instance;
+        return $this->target->construct([$arrayValue]);
     }
 
     /**

--- a/src/Schema/ListSchema.php
+++ b/src/Schema/ListSchema.php
@@ -51,7 +51,7 @@ final class ListSchema implements Schema
             return $value;
         }
         $arrayValue = $this->coerce($value, $options);
-        return $this->target->construct([$arrayValue]);
+        return $this->target->construct($this, [$arrayValue]);
     }
 
     /**

--- a/src/Schema/ShapeSchema.php
+++ b/src/Schema/ShapeSchema.php
@@ -4,20 +4,17 @@ declare(strict_types=1);
 
 namespace Wwwision\Types\Schema;
 
-use ReflectionClass;
-use ReflectionException;
-use ReflectionMethod;
-use RuntimeException;
 use Webmozart\Assert\Assert;
 use Wwwision\Types\Attributes\Discriminator;
 use Wwwision\Types\Exception\CoerceException;
 use Wwwision\Types\Exception\InvalidSchemaException;
 use Wwwision\Types\Exception\Issues\Issues;
-
 use Wwwision\Types\Options;
+use Wwwision\Types\Schema\Target\Target;
 
 use function array_diff_key;
 use function array_key_exists;
+use function get_debug_type;
 use function get_object_vars;
 use function is_array;
 use function is_iterable;
@@ -28,13 +25,12 @@ use function sprintf;
 final class ShapeSchema implements Schema
 {
     /**
-     * @param ReflectionClass<object> $reflectionClass
      * @param array<non-empty-string, Schema> $propertySchemas
      * @param array<non-empty-string, string> $overriddenPropertyDescriptions
      * @param array<non-empty-string, Discriminator> $propertyDiscriminators
      */
     public function __construct(
-        private readonly ReflectionClass $reflectionClass,
+        private readonly Target $target,
         public readonly string|null $description,
         public readonly array $propertySchemas,
         private readonly array $overriddenPropertyDescriptions,
@@ -51,7 +47,7 @@ final class ShapeSchema implements Schema
 
     public function getName(): string
     {
-        return $this->reflectionClass->getShortName();
+        return $this->target->name();
     }
 
     public function getDescription(): string|null
@@ -64,29 +60,18 @@ final class ShapeSchema implements Schema
         return $this->overriddenPropertyDescriptions[$propertyName] ?? null;
     }
 
-    /** @phpstan-assert-if-true object $value */
     public function isInstance(mixed $value): bool
     {
-        return is_object($value) && $this->reflectionClass->isInstance($value);
+        return $this->target->isInstance($value);
     }
 
     public function instantiate(mixed $value, Options $options): mixed
     {
-        if ($this->isInstance($value)) {
+        if ($this->target->isInstance($value)) {
             return $value;
         }
         $arrayValue = $this->coerce($value, $options);
-        $constructor = $this->reflectionClass->getConstructor();
-        Assert::isInstanceOf($constructor, ReflectionMethod::class, sprintf('Missing constructor in class "%s"', $this->reflectionClass->getName()));
-        try {
-            $instance = $this->reflectionClass->newInstanceWithoutConstructor();
-            $constructor->invoke($instance, ...$arrayValue);
-            // @codeCoverageIgnoreStart
-        } catch (ReflectionException $e) {
-            throw new RuntimeException(sprintf('Failed to instantiate "%s": %s', $this->getName(), $e->getMessage()), 1688570532, $e);
-        }
-        // @codeCoverageIgnoreEnd
-        return $instance;
+        return $this->target->construct($arrayValue);
     }
 
     /**

--- a/src/Schema/ShapeSchema.php
+++ b/src/Schema/ShapeSchema.php
@@ -71,7 +71,7 @@ final class ShapeSchema implements Schema
             return $value;
         }
         $arrayValue = $this->coerce($value, $options);
-        return $this->target->construct($arrayValue);
+        return $this->target->construct($this, $arrayValue);
     }
 
     /**

--- a/src/Schema/StringSchema.php
+++ b/src/Schema/StringSchema.php
@@ -5,21 +5,15 @@ declare(strict_types=1);
 namespace Wwwision\Types\Schema;
 
 use Ramsey\Uuid\Uuid;
-use ReflectionClass;
-use ReflectionException;
-use ReflectionMethod;
-use RuntimeException;
 use Stringable;
-use Webmozart\Assert\Assert;
 use Wwwision\Types\Exception\CoerceException;
 use Wwwision\Types\Exception\Issues\Issues;
-
 use Wwwision\Types\Options;
+use Wwwision\Types\Schema\Target\Target;
 
 use function filter_var;
 use function is_string;
 use function preg_match;
-use function sprintf;
 use function strlen;
 
 use const FILTER_VALIDATE_EMAIL;
@@ -28,12 +22,11 @@ use const FILTER_VALIDATE_URL;
 final class StringSchema implements Schema
 {
     /**
-     * @param ReflectionClass<object> $reflectionClass
      * @param array<string>|null $examples
      * @param array<string, mixed>|null $extensions
      */
     public function __construct(
-        private readonly ReflectionClass $reflectionClass,
+        private readonly Target $target,
         public readonly string|null $description,
         public readonly int|null $minLength = null,
         public readonly int|null $maxLength = null,
@@ -50,7 +43,7 @@ final class StringSchema implements Schema
 
     public function getName(): string
     {
-        return $this->reflectionClass->getShortName();
+        return $this->target->name();
     }
 
     public function getDescription(): string|null
@@ -58,29 +51,18 @@ final class StringSchema implements Schema
         return $this->description;
     }
 
-    /** @phpstan-assert-if-true object $value */
     public function isInstance(mixed $value): bool
     {
-        return is_object($value) && $this->reflectionClass->isInstance($value);
+        return $this->target->isInstance($value);
     }
 
-    public function instantiate(mixed $value, Options $options): object
+    public function instantiate(mixed $value, Options $options): mixed
     {
-        if ($this->isInstance($value)) {
+        if ($this->target->isInstance($value)) {
             return $value;
         }
         $stringValue = $this->coerce($value);
-        $constructor = $this->reflectionClass->getConstructor();
-        Assert::isInstanceOf($constructor, ReflectionMethod::class, sprintf('Missing constructor in class "%s"', $this->reflectionClass->getName()));
-        try {
-            $instance = $this->reflectionClass->newInstanceWithoutConstructor();
-            $constructor->invoke($instance, $stringValue);
-            // @codeCoverageIgnoreStart
-        } catch (ReflectionException $e) {
-            throw new RuntimeException(sprintf('Failed to instantiate "%s": %s', $this->getName(), $e->getMessage()), 1688570532, $e);
-        }
-        // @codeCoverageIgnoreEnd
-        return $instance;
+        return $this->target->construct([$stringValue]);
     }
 
     private function coerce(mixed $value): string
@@ -109,18 +91,11 @@ final class StringSchema implements Schema
                 StringTypeFormat::email => filter_var($value, FILTER_VALIDATE_EMAIL) !== false,
                 StringTypeFormat::hostname => preg_match('/^(?!\d+$)(?!-)[[:alnum:]-]{0,63}(?<!-)$/', $value) === 1,
                 StringTypeFormat::idn_email => count(explode('@', $value, 3)) === 2,
-                //StringTypeFormat::idn_hostname => throw new \Exception('To be implemented'),
                 StringTypeFormat::ipv4 => filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false,
                 StringTypeFormat::ipv6 => filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false,
-                //StringTypeFormat::iri => throw new \Exception('To be implemented'),
-                //StringTypeFormat::iri_reference => throw new \Exception('To be implemented'),
-                //StringTypeFormat::json_pointer => throw new \Exception('To be implemented'),
                 StringTypeFormat::regex => @preg_match('/' . $value . '/', '') !== false,
-                //StringTypeFormat::relative_json_pointer => throw new \Exception('To be implemented'),
                 StringTypeFormat::time => preg_match('/^([01]\d|2[0-3]):([0-5]\d):([0-5]\d|60)(\.\d+)?(Z|[+-]([01]\d|2[0-3]):?([0-5]\d)?)?$/i', $value) === 1,
                 StringTypeFormat::uri => filter_var($value, FILTER_VALIDATE_URL) !== false,
-                //StringTypeFormat::uri_reference => throw new \Exception('To be implemented'),
-                //StringTypeFormat::uri_template => throw new \Exception('To be implemented'),
                 StringTypeFormat::uuid => Uuid::isValid($value),
             };
             if (!$matchesFormat) {

--- a/src/Schema/StringSchema.php
+++ b/src/Schema/StringSchema.php
@@ -62,7 +62,7 @@ final class StringSchema implements Schema
             return $value;
         }
         $stringValue = $this->coerce($value);
-        return $this->target->construct([$stringValue]);
+        return $this->target->construct($this, [$stringValue]);
     }
 
     private function coerce(mixed $value): string

--- a/src/Schema/Target/ClassTarget.php
+++ b/src/Schema/Target/ClassTarget.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\Types\Schema\Target;
+
+use ReflectionClass;
+use ReflectionException;
+use ReflectionMethod;
+use RuntimeException;
+use Webmozart\Assert\Assert;
+
+use function sprintf;
+
+/**
+ * A {@see Target} backed by a real PHP class. Reproduces the original reflection-based behavior:
+ * names itself from the class, checks `instanceof`, and constructs via the private constructor.
+ */
+final class ClassTarget implements Target
+{
+    /**
+     * @param ReflectionClass<object> $reflectionClass
+     */
+    public function __construct(
+        public readonly ReflectionClass $reflectionClass,
+    ) {}
+
+    public function name(): string
+    {
+        return $this->reflectionClass->getShortName();
+    }
+
+    public function isInstance(mixed $value): bool
+    {
+        return is_object($value) && $this->reflectionClass->isInstance($value);
+    }
+
+    public function construct(array $arguments): mixed
+    {
+        $constructor = $this->reflectionClass->getConstructor();
+        Assert::isInstanceOf($constructor, ReflectionMethod::class, sprintf('Missing constructor in class "%s"', $this->reflectionClass->getName()));
+        try {
+            $instance = $this->reflectionClass->newInstanceWithoutConstructor();
+            $constructor->invoke($instance, ...$arguments);
+            // @codeCoverageIgnoreStart
+        } catch (ReflectionException $e) {
+            throw new RuntimeException(sprintf('Failed to instantiate "%s": %s', $this->name(), $e->getMessage()), 1688570532, $e);
+        }
+        // @codeCoverageIgnoreEnd
+        return $instance;
+    }
+}

--- a/src/Schema/Target/ClassTarget.php
+++ b/src/Schema/Target/ClassTarget.php
@@ -9,6 +9,7 @@ use ReflectionException;
 use ReflectionMethod;
 use RuntimeException;
 use Webmozart\Assert\Assert;
+use Wwwision\Types\Schema\Schema;
 
 use function sprintf;
 
@@ -35,7 +36,7 @@ final class ClassTarget implements Target
         return is_object($value) && $this->reflectionClass->isInstance($value);
     }
 
-    public function construct(array $arguments): mixed
+    public function construct(Schema $schema, array $arguments): mixed
     {
         $constructor = $this->reflectionClass->getConstructor();
         Assert::isInstanceOf($constructor, ReflectionMethod::class, sprintf('Missing constructor in class "%s"', $this->reflectionClass->getName()));

--- a/src/Schema/Target/DynamicTarget.php
+++ b/src/Schema/Target/DynamicTarget.php
@@ -9,9 +9,12 @@ use Wwwision\Types\Schema\Dynamic\DynamicInstance;
 use Wwwision\Types\Schema\Dynamic\DynamicList;
 use Wwwision\Types\Schema\Dynamic\DynamicRecord;
 use Wwwision\Types\Schema\Dynamic\DynamicValue;
+use Wwwision\Types\Schema\FloatSchema;
+use Wwwision\Types\Schema\IntegerSchema;
 use Wwwision\Types\Schema\ListSchema;
 use Wwwision\Types\Schema\Schema;
 use Wwwision\Types\Schema\ShapeSchema;
+use Wwwision\Types\Schema\StringSchema;
 
 use function is_array;
 use function is_scalar;
@@ -37,6 +40,7 @@ final class DynamicTarget implements Target
         return new self($name, static function (Schema $schema, array $arguments): DynamicValue {
             $value = reset($arguments);
             assert(is_scalar($value));
+            assert($schema instanceof StringSchema || $schema instanceof IntegerSchema || $schema instanceof FloatSchema);
             return new DynamicValue($schema, $value);
         });
     }

--- a/src/Schema/Target/DynamicTarget.php
+++ b/src/Schema/Target/DynamicTarget.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\Types\Schema\Target;
+
+use Closure;
+use Wwwision\Types\Schema\Dynamic\DynamicInstance;
+
+/**
+ * A {@see Target} backed by nothing. Names itself from a given string and builds a generic
+ * {@see DynamicInstance} container via a factory closure, instead of a real PHP class.
+ */
+final class DynamicTarget implements Target
+{
+    /**
+     * @param Closure(array<int|string, mixed>): DynamicInstance $factory
+     */
+    public function __construct(
+        public readonly string $name,
+        private readonly Closure $factory,
+    ) {}
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function isInstance(mixed $value): bool
+    {
+        return $value instanceof DynamicInstance && $value->typeName === $this->name;
+    }
+
+    public function construct(array $arguments): mixed
+    {
+        return ($this->factory)($arguments);
+    }
+}

--- a/src/Schema/Target/DynamicTarget.php
+++ b/src/Schema/Target/DynamicTarget.php
@@ -6,20 +6,64 @@ namespace Wwwision\Types\Schema\Target;
 
 use Closure;
 use Wwwision\Types\Schema\Dynamic\DynamicInstance;
+use Wwwision\Types\Schema\Dynamic\DynamicList;
+use Wwwision\Types\Schema\Dynamic\DynamicRecord;
+use Wwwision\Types\Schema\Dynamic\DynamicValue;
+use Wwwision\Types\Schema\ListSchema;
+use Wwwision\Types\Schema\Schema;
+use Wwwision\Types\Schema\ShapeSchema;
+
+use function is_array;
+use function is_scalar;
+use function reset;
 
 /**
  * A {@see Target} backed by nothing. Names itself from a given string and builds a generic
- * {@see DynamicInstance} container via a factory closure, instead of a real PHP class.
+ * {@see DynamicInstance} container (carrying the owning {@see Schema}) instead of a real PHP class.
  */
 final class DynamicTarget implements Target
 {
     /**
-     * @param Closure(array<int|string, mixed>): DynamicInstance $factory
+     * @param Closure(Schema, array<int|string, mixed>): DynamicInstance $factory
      */
     public function __construct(
         public readonly string $name,
         private readonly Closure $factory,
     ) {}
+
+    /** Builds {@see DynamicValue} containers (scalar leaf schemas). */
+    public static function scalar(string $name): self
+    {
+        return new self($name, static function (Schema $schema, array $arguments): DynamicValue {
+            $value = reset($arguments);
+            assert(is_scalar($value));
+            return new DynamicValue($schema, $value);
+        });
+    }
+
+    /** Builds {@see DynamicRecord} containers (shape schemas). */
+    public static function record(string $name): self
+    {
+        return new self($name, static function (Schema $schema, array $arguments): DynamicRecord {
+            assert($schema instanceof ShapeSchema);
+            $properties = [];
+            foreach ($arguments as $key => $value) {
+                $properties[(string) $key] = $value;
+            }
+            return new DynamicRecord($schema, $properties);
+        });
+    }
+
+    /** Builds {@see DynamicList} containers (list schemas). */
+    public static function list(string $name): self
+    {
+        return new self($name, static function (Schema $schema, array $arguments): DynamicList {
+            assert($schema instanceof ListSchema);
+            $items = reset($arguments);
+            assert(is_array($items));
+            return new DynamicList($schema, $items);
+        });
+    }
 
     public function name(): string
     {
@@ -28,11 +72,11 @@ final class DynamicTarget implements Target
 
     public function isInstance(mixed $value): bool
     {
-        return $value instanceof DynamicInstance && $value->typeName === $this->name;
+        return $value instanceof DynamicInstance && $value->getSchema()->getName() === $this->name;
     }
 
-    public function construct(array $arguments): mixed
+    public function construct(Schema $schema, array $arguments): mixed
     {
-        return ($this->factory)($arguments);
+        return ($this->factory)($schema, $arguments);
     }
 }

--- a/src/Schema/Target/Target.php
+++ b/src/Schema/Target/Target.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace Wwwision\Types\Schema\Target;
 
+use Wwwision\Types\Schema\Schema;
+
 /**
- * The "thing" a {@see \Wwwision\Types\Schema\Schema} represents and instantiates into.
+ * The "thing" a {@see Schema} represents and instantiates into.
  *
  * This is the single seam that lets one set of schema classes serve both modes:
  *  - {@see ClassTarget}   — backed by a real PHP class (the original behavior)
  *  - {@see DynamicTarget} — backed by nothing; instantiates to a generic container
  *
  * A schema keeps all of its (unchanged) coercion/validation logic and only delegates the three
- * class-coupled concerns — naming, instance checking, and the final "build the object" step —
+ * class-coupled concerns — naming, instance checking, and the final "build the value" step —
  * to its Target.
  */
 interface Target
@@ -23,8 +25,10 @@ interface Target
 
     /**
      * Builds the final value from already-coerced constructor arguments (positional or named).
+     * The owning $schema is passed so a {@see DynamicTarget} can embed it into the produced
+     * {@see \Wwwision\Types\Schema\Dynamic\DynamicInstance}.
      *
      * @param array<int|string, mixed> $arguments
      */
-    public function construct(array $arguments): mixed;
+    public function construct(Schema $schema, array $arguments): mixed;
 }

--- a/src/Schema/Target/Target.php
+++ b/src/Schema/Target/Target.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\Types\Schema\Target;
+
+/**
+ * The "thing" a {@see \Wwwision\Types\Schema\Schema} represents and instantiates into.
+ *
+ * This is the single seam that lets one set of schema classes serve both modes:
+ *  - {@see ClassTarget}   — backed by a real PHP class (the original behavior)
+ *  - {@see DynamicTarget} — backed by nothing; instantiates to a generic container
+ *
+ * A schema keeps all of its (unchanged) coercion/validation logic and only delegates the three
+ * class-coupled concerns — naming, instance checking, and the final "build the object" step —
+ * to its Target.
+ */
+interface Target
+{
+    public function name(): string;
+
+    public function isInstance(mixed $value): bool;
+
+    /**
+     * Builds the final value from already-coerced constructor arguments (positional or named).
+     *
+     * @param array<int|string, mixed> $arguments
+     */
+    public function construct(array $arguments): mixed;
+}

--- a/tests/PHPUnit/DynamicSchemaTest.php
+++ b/tests/PHPUnit/DynamicSchemaTest.php
@@ -109,6 +109,44 @@ final class DynamicSchemaTest extends TestCase
         self::assertSame('JJ', $nickname->value);
     }
 
+    public function test_dynamic_record_exposes_its_schema_and_is_iterable(): void
+    {
+        $schema = DynamicSchema::shape('Coordinate', [
+            'latitude' => DynamicSchema::float('Latitude'),
+            'longitude' => DynamicSchema::float('Longitude'),
+        ]);
+        $record = $schema->instantiate(['latitude' => 51.5, 'longitude' => -0.1], Options::create());
+        self::assertInstanceOf(DynamicRecord::class, $record);
+
+        // it carries its schema, so consumers can introspect names/types/descriptions
+        self::assertSame($schema, $record->getSchema());
+        self::assertSame(['latitude', 'longitude'], array_keys($record->getSchema()->propertySchemas));
+        self::assertSame(['latitude', 'longitude'], $record->propertyNames());
+
+        // ...and it is iterable as propertyName => value
+        $collected = [];
+        foreach ($record as $name => $value) {
+            self::assertInstanceOf(DynamicValue::class, $value);
+            $collected[$name] = $value->value;
+        }
+        self::assertSame(['latitude' => 51.5, 'longitude' => -0.1], $collected);
+    }
+
+    public function test_dynamic_value_and_list_expose_their_schema(): void
+    {
+        $listSchema = DynamicSchema::list('Tags', DynamicSchema::string('Tag'));
+        $list = $listSchema->instantiate(['a', 'b'], Options::create());
+        self::assertInstanceOf(DynamicList::class, $list);
+        self::assertSame($listSchema, $list->getSchema());
+
+        $first = $listSchema->instantiate(['x'], Options::create());
+        self::assertInstanceOf(DynamicList::class, $first);
+        foreach ($first as $tag) {
+            self::assertInstanceOf(DynamicValue::class, $tag);
+            self::assertSame('Tag', $tag->getSchema()->getName());
+        }
+    }
+
     public function test_dynamic_integer_validates_and_wraps(): void
     {
         $schema = DynamicSchema::integer('Quantity', minimum: 1, maximum: 10);

--- a/tests/PHPUnit/DynamicSchemaTest.php
+++ b/tests/PHPUnit/DynamicSchemaTest.php
@@ -77,7 +77,7 @@ final class DynamicSchemaTest extends TestCase
 
         self::assertInstanceOf(DynamicRecord::class, $result);
         // the inherited, class-based property is still a real, validated value object
-        $name = $result['name'];
+        $name = $result->get('name');
         self::assertInstanceOf(Fixture\FamilyName::class, $name);
         self::assertSame('Doe', $name->value);
     }
@@ -102,9 +102,9 @@ final class DynamicSchemaTest extends TestCase
         $result = $extended->instantiate(['givenName' => 'Jane', 'familyName' => 'Doe', 'nickname' => 'JJ'], Options::create());
 
         self::assertInstanceOf(DynamicRecord::class, $result);
-        self::assertInstanceOf(Fixture\GivenName::class, $result['givenName']);
-        self::assertInstanceOf(Fixture\FamilyName::class, $result['familyName']);
-        $nickname = $result['nickname'];
+        self::assertInstanceOf(Fixture\GivenName::class, $result->get('givenName'));
+        self::assertInstanceOf(Fixture\FamilyName::class, $result->get('familyName'));
+        $nickname = $result->get('nickname');
         self::assertInstanceOf(DynamicValue::class, $nickname);
         self::assertSame('JJ', $nickname->value);
     }

--- a/tests/PHPUnit/DynamicSchemaTest.php
+++ b/tests/PHPUnit/DynamicSchemaTest.php
@@ -147,6 +147,15 @@ final class DynamicSchemaTest extends TestCase
         }
     }
 
+    public function test_dynamic_record_is_immutable(): void
+    {
+        $record = DynamicSchema::shape('Point', ['x' => DynamicSchema::integer('X')])
+            ->instantiate(['x' => 1], Options::create());
+        self::assertInstanceOf(DynamicRecord::class, $record);
+        $this->expectException(\LogicException::class);
+        $record->__set('x', 2);
+    }
+
     public function test_dynamic_integer_validates_and_wraps(): void
     {
         $schema = DynamicSchema::integer('Quantity', minimum: 1, maximum: 10);

--- a/tests/PHPUnit/DynamicSchemaTest.php
+++ b/tests/PHPUnit/DynamicSchemaTest.php
@@ -9,9 +9,12 @@ use PHPUnit\Framework\TestCase;
 use Wwwision\Types\DynamicSchema;
 use Wwwision\Types\Options;
 use Wwwision\Types\Parser;
+use Wwwision\Types\Schema\Dynamic\DynamicList;
 use Wwwision\Types\Schema\Dynamic\DynamicRecord;
 use Wwwision\Types\Schema\Dynamic\DynamicValue;
 use Wwwision\Types\Schema\Dynamic\ShapeExtender;
+use Wwwision\Types\Schema\IntegerSchema;
+use Wwwision\Types\Schema\ListSchema;
 use Wwwision\Types\Schema\Schema;
 use Wwwision\Types\Schema\ShapeSchema;
 use Wwwision\Types\Schema\StringSchema;
@@ -28,9 +31,12 @@ require_once __DIR__ . '/../Fixture/Fixture.php';
 #[CoversClass(ClassTarget::class)]
 #[CoversClass(DynamicRecord::class)]
 #[CoversClass(DynamicValue::class)]
+#[CoversClass(DynamicList::class)]
 #[CoversClass(ShapeExtender::class)]
 #[CoversClass(StringSchema::class)]
 #[CoversClass(ShapeSchema::class)]
+#[CoversClass(IntegerSchema::class)]
+#[CoversClass(ListSchema::class)]
 #[CoversClass(Parser::class)]
 final class DynamicSchemaTest extends TestCase
 {
@@ -101,6 +107,25 @@ final class DynamicSchemaTest extends TestCase
         $nickname = $result['nickname'];
         self::assertInstanceOf(DynamicValue::class, $nickname);
         self::assertSame('JJ', $nickname->value);
+    }
+
+    public function test_dynamic_integer_validates_and_wraps(): void
+    {
+        $schema = DynamicSchema::integer('Quantity', minimum: 1, maximum: 10);
+        $result = $schema->instantiate('5', Options::create());
+        self::assertInstanceOf(DynamicValue::class, $result);
+        self::assertSame(5, $result->value);
+    }
+
+    public function test_dynamic_list_of_real_value_objects(): void
+    {
+        $schema = DynamicSchema::list('FamilyNames', Parser::getSchema(Fixture\FamilyName::class), minCount: 1);
+        $result = $schema->instantiate(['Doe', 'Roe'], Options::create());
+        self::assertInstanceOf(DynamicList::class, $result);
+        self::assertCount(2, $result);
+        foreach ($result as $item) {
+            self::assertInstanceOf(Fixture\FamilyName::class, $item);
+        }
     }
 
     public function test_a_consumer_typed_against_schema_treats_both_identically(): void

--- a/tests/PHPUnit/DynamicSchemaTest.php
+++ b/tests/PHPUnit/DynamicSchemaTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wwwision\Types\Tests\PHPUnit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Wwwision\Types\DynamicSchema;
+use Wwwision\Types\Options;
+use Wwwision\Types\Parser;
+use Wwwision\Types\Schema\Dynamic\DynamicRecord;
+use Wwwision\Types\Schema\Dynamic\DynamicValue;
+use Wwwision\Types\Schema\Dynamic\ShapeExtender;
+use Wwwision\Types\Schema\Schema;
+use Wwwision\Types\Schema\ShapeSchema;
+use Wwwision\Types\Schema\StringSchema;
+use Wwwision\Types\Schema\Target\ClassTarget;
+use Wwwision\Types\Schema\Target\DynamicTarget;
+use Wwwision\Types\Tests\Fixture;
+
+use function Wwwision\Types\instantiate;
+
+require_once __DIR__ . '/../Fixture/Fixture.php';
+
+#[CoversClass(DynamicSchema::class)]
+#[CoversClass(DynamicTarget::class)]
+#[CoversClass(ClassTarget::class)]
+#[CoversClass(DynamicRecord::class)]
+#[CoversClass(DynamicValue::class)]
+#[CoversClass(ShapeExtender::class)]
+#[CoversClass(StringSchema::class)]
+#[CoversClass(ShapeSchema::class)]
+#[CoversClass(Parser::class)]
+final class DynamicSchemaTest extends TestCase
+{
+    public function test_class_based_instantiation_is_unchanged(): void
+    {
+        $familyName = instantiate(Fixture\FamilyName::class, 'Doe');
+        self::assertInstanceOf(Fixture\FamilyName::class, $familyName);
+        self::assertSame('Doe', $familyName->value);
+
+        $fullName = instantiate(Fixture\FullName::class, ['givenName' => 'Jane', 'familyName' => 'Doe']);
+        self::assertInstanceOf(Fixture\FullName::class, $fullName);
+        self::assertSame('Jane', $fullName->givenName->value);
+    }
+
+    public function test_class_based_and_dynamic_schemas_share_the_same_implementation(): void
+    {
+        $classBased = Parser::getSchema(Fixture\FullName::class);
+        $dynamic = DynamicSchema::shape('Point', [
+            'x' => DynamicSchema::string('X'),
+            'y' => DynamicSchema::string('Y'),
+        ]);
+        // No separate "DynamicShapeSchema" type – both are the very same class.
+        self::assertInstanceOf(ShapeSchema::class, $classBased);
+        self::assertInstanceOf(ShapeSchema::class, $dynamic);
+        // ...and a consumer that only knows the Schema interface sees an identical surface.
+        self::assertSame(['type', 'name', 'description', 'properties'], array_keys($classBased->jsonSerialize()));
+        self::assertSame(['type', 'name', 'description', 'properties'], array_keys($dynamic->jsonSerialize()));
+        self::assertSame('object', $dynamic->getType());
+        self::assertSame('Point', $dynamic->getName());
+    }
+
+    public function test_dynamic_shape_instantiates_to_a_record_reusing_real_value_objects(): void
+    {
+        $schema = DynamicSchema::shape('Greeting', [
+            'name' => Parser::getSchema(Fixture\FamilyName::class),
+        ]);
+        $result = $schema->instantiate(['name' => 'Doe'], Options::create());
+
+        self::assertInstanceOf(DynamicRecord::class, $result);
+        // the inherited, class-based property is still a real, validated value object
+        $name = $result['name'];
+        self::assertInstanceOf(Fixture\FamilyName::class, $name);
+        self::assertSame('Doe', $name->value);
+    }
+
+    public function test_dynamic_scalar_validates_and_wraps(): void
+    {
+        $schema = DynamicSchema::string('Code', minLength: 2, maxLength: 4);
+        $result = $schema->instantiate('AB', Options::create());
+        self::assertInstanceOf(DynamicValue::class, $result);
+        self::assertSame('AB', $result->value);
+    }
+
+    public function test_extending_a_class_based_shape_keeps_inherited_value_objects(): void
+    {
+        $base = Parser::getSchema(Fixture\FullName::class);
+        self::assertInstanceOf(ShapeSchema::class, $base);
+
+        $extended = DynamicSchema::extend($base, 'ExtendedFullName')
+            ->withProperty('nickname', DynamicSchema::string('Nickname'))
+            ->build();
+
+        $result = $extended->instantiate(['givenName' => 'Jane', 'familyName' => 'Doe', 'nickname' => 'JJ'], Options::create());
+
+        self::assertInstanceOf(DynamicRecord::class, $result);
+        self::assertInstanceOf(Fixture\GivenName::class, $result['givenName']);
+        self::assertInstanceOf(Fixture\FamilyName::class, $result['familyName']);
+        $nickname = $result['nickname'];
+        self::assertInstanceOf(DynamicValue::class, $nickname);
+        self::assertSame('JJ', $nickname->value);
+    }
+
+    public function test_a_consumer_typed_against_schema_treats_both_identically(): void
+    {
+        $describe = static fn(Schema $schema): string => $schema->getType() . ':' . $schema->getName();
+        self::assertSame('object:FullName', $describe(Parser::getSchema(Fixture\FullName::class)));
+        self::assertSame('object:Point', $describe(DynamicSchema::shape('Point', [])));
+    }
+}


### PR DESCRIPTION
## Motivation

Schemas are normally derived from PHP classes via `Parser::getSchema()`. This PR makes it possible
to build schemas that are **not** backed by a class — defined at runtime, loaded from configuration,
or assembled on the fly — and to **extend** existing class-based schemas (add/remove properties).

## Approach — a `Target` seam

Rather than a second schema hierarchy, each schema keeps its existing coercion/validation logic and
delegates only its three class-coupled concerns — naming, instance-checking and the final
"build the value" step — to a `Target`:

- `ClassTarget` — wraps a `ReflectionClass`; the original behavior, unchanged.
- `DynamicTarget` — builds a generic immutable container instead of a real class.

Key consequence: **there is no separate `DynamicShapeSchema`**. `Parser::getSchema(X)` and
`DynamicSchema::shape(...)` return the *same* `ShapeSchema`, so anything consuming a `Schema`
(serialization, introspection, integrations) treats both identically. The dynamic-ness surfaces only
in the instantiated *value* (a container vs. a real object).

Rolled through every constructor-based kind: `String`, `Integer`, `Float`, `List`, `Shape`.
`OneOf` holds no class and needs none. `Enum` (value→case resolution) and `Interface` (discriminated
dispatch) are intentionally left class-backed — their instantiation is not construction, so forcing
them through the seam would distort it. See `docs/adr/0001-target-seam-for-dynamic-schemas.md`.

## What's included

- `DynamicSchema::string|integer|float|list|shape(...)` builders.
- `DynamicSchema::extend($shapeSchema, $name)->withProperty()/withoutProperty()->build()`.
- Immutable containers `DynamicValue` / `DynamicRecord` / `DynamicList`, each carrying the `Schema`
  they were instantiated from (`getSchema()`, with precise return types), so consumers can introspect
  names/types/descriptions without a backing class. `DynamicRecord` reads via `$record->prop`
  (object-accessor), is iterable as `propertyName => value`, and rejects writes (immutable).

## Example

```php
$schema = DynamicSchema::shape('Coordinate', [
    'latitude'  => DynamicSchema::float('Latitude', minimum: -90, maximum: 90),
    'longitude' => DynamicSchema::float('Longitude', minimum: -180, maximum: 180),
]);

$coordinate = $schema->instantiate(['latitude' => 51.5, 'longitude' => -0.1], Options::create());
$coordinate->latitude->value; // 51.5
```

Extending a class-based schema keeps inherited properties as real, validated value objects:

```php
$extended = DynamicSchema::extend(Parser::getSchema(Product::class), 'DiscountedProduct')
    ->withProperty('discount', DynamicSchema::integer('Discount', minimum: 0, maximum: 100))
    ->build();
```

## Compatibility & quality

- **Non-breaking**: the reflection path is unchanged; all existing tests pass untouched. Candidate
  for a minor release.
- Green across the board: **PHPStan level 9, PHP-CS-Fixer, 419 PHPUnit tests** (incl. README code
  blocks, which are executed by the test suite).
- Documented in `README.md` ("Dynamic schemas") and an ADR.

## Deferred follow-ups (not in this PR)

- A first-class dynamic **enum** (would roll the seam through `EnumSchema` and make `EnumCaseSchema`
  data-only). An "enum-like" type is available today via a constrained `DynamicSchema::string(pattern: ...)`.
- Dynamic **interfaces** (dispatch among registered schemas).
- A PHPStan extension in `wwwision/types-phpstan` to type `$record->prop` for inline-built schemas
  (runtime-built schemas stay `mixed`; `get()`/`has()` is the fallback).