### PR TITLE
Expose constructor default values on ShapeSchema

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,7 +529,18 @@ assert($person->isRegistered === false);
 $schema = Parser::getSchema(Contact::class);
 assert($schema->getDescription() === 'A contact in the system');
 assert($schema->propertySchemas['isRegistered']->getDescription() === 'Whether the contact is registered or not');
+
+// Constructor default values are exposed on the ShapeSchema (e.g. to pre-fill form fields)
+assert($schema->hasDefaultValue('isRegistered') === true);
+assert($schema->defaultValue('isRegistered') === false);
+
+// Properties without a constructor default are reported as such
+assert($schema->hasDefaultValue('title') === false);
 ```
+
+> [!NOTE]
+> `defaultValue()` returns the **raw** reflected default value (a scalar, `null`, an array or an enum case – e.g. `Title::MR`), so a default of `null` is distinguishable from "no default" via `hasDefaultValue()`.
+> Calling `defaultValue()` for a property without a default throws an `InvalidArgumentException`, so guard it with `hasDefaultValue()`.
 
 </details>
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -193,8 +193,12 @@ final class Parser
         $propertySchemas = [];
         $overriddenPropertyDescriptions = [];
         $propertyDiscriminators = [];
+        $propertyDefaults = [];
         foreach ($constructor->getParameters() as $parameter) {
             $propertyName = $parameter->getName();
+            if ($parameter->isDefaultValueAvailable()) {
+                $propertyDefaults[$propertyName] = $parameter->getDefaultValue();
+            }
             $parameterType = $parameter->getType();
             Assert::notNull($parameterType, sprintf('Failed to determine type of constructor parameter "%s"', $propertyName));
             Assert::isInstanceOfAny($parameterType, [ReflectionNamedType::class, ReflectionUnionType::class, ReflectionIntersectionType::class]);
@@ -222,7 +226,7 @@ final class Parser
             }
             $propertySchemas[$propertyName] = $propertySchema;
         }
-        return new ShapeSchema(new ClassTarget($reflectionClass), self::getDescription($reflectionClass), $propertySchemas, $overriddenPropertyDescriptions, $propertyDiscriminators);
+        return new ShapeSchema(new ClassTarget($reflectionClass), self::getDescription($reflectionClass), $propertySchemas, $overriddenPropertyDescriptions, $propertyDiscriminators, $propertyDefaults);
     }
 
     /**

--- a/src/Schema/ShapeSchema.php
+++ b/src/Schema/ShapeSchema.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Wwwision\Types\Schema;
 
+use InvalidArgumentException;
 use Webmozart\Assert\Assert;
 use Wwwision\Types\Attributes\Discriminator;
 use Wwwision\Types\Exception\CoerceException;
@@ -28,6 +29,7 @@ final class ShapeSchema implements Schema
      * @param array<non-empty-string, Schema> $propertySchemas
      * @param array<non-empty-string, string> $overriddenPropertyDescriptions
      * @param array<non-empty-string, Discriminator> $propertyDiscriminators
+     * @param array<non-empty-string, mixed> $propertyDefaults the raw constructor default values, keyed by property name (presence means "has a default", so a default of null is distinguishable from "no default")
      */
     public function __construct(
         private readonly Target $target,
@@ -35,6 +37,7 @@ final class ShapeSchema implements Schema
         public readonly array $propertySchemas,
         private readonly array $overriddenPropertyDescriptions,
         private readonly array $propertyDiscriminators,
+        private readonly array $propertyDefaults = [],
     ) {
         Assert::allIsInstanceOf($this->propertySchemas, Schema::class);
         Assert::allIsInstanceOf($this->propertyDiscriminators, Discriminator::class);
@@ -58,6 +61,31 @@ final class ShapeSchema implements Schema
     public function overriddenPropertyDescription(string $propertyName): string|null
     {
         return $this->overriddenPropertyDescriptions[$propertyName] ?? null;
+    }
+
+    /**
+     * Whether the property with the given name has a constructor default value.
+     *
+     * Note: This is distinct from the property being optional – a property of type `?string $foo` (without
+     * default) is optional but has no default, whereas `string $foo = 'bar'` has the default value "bar".
+     */
+    public function hasDefaultValue(string $propertyName): bool
+    {
+        return array_key_exists($propertyName, $this->propertyDefaults);
+    }
+
+    /**
+     * The raw constructor default value of the property with the given name (e.g. the string "bar" for
+     * `string $foo = 'bar'`, or an enum case for `Suit $suit = Suit::Hearts`).
+     *
+     * @throws InvalidArgumentException if the property has no default value – use {@see self::hasDefaultValue()} to check
+     */
+    public function defaultValue(string $propertyName): mixed
+    {
+        if (!array_key_exists($propertyName, $this->propertyDefaults)) {
+            throw new InvalidArgumentException(sprintf('Property "%s" of type "%s" has no default value', $propertyName, $this->getName()), 1782518400);
+        }
+        return $this->propertyDefaults[$propertyName];
     }
 
     public function isInstance(mixed $value): bool

--- a/tests/Fixture/Fixture.php
+++ b/tests/Fixture/Fixture.php
@@ -285,6 +285,13 @@ final class ShapeWithOptionalTypes
     ) {}
 }
 
+final class ShapeWithEnumDefault
+{
+    public function __construct(
+        public readonly Title $title = Title::MR,
+    ) {}
+}
+
 final class ShapeWithInvalidObjectProperty
 {
     public function __construct(

--- a/tests/PHPUnit/IntegrationTest.php
+++ b/tests/PHPUnit/IntegrationTest.php
@@ -251,6 +251,42 @@ final class IntegrationTest extends TestCase
         self::assertSame(['x-editor' => 'ImageEditor', 'x-mime' => 'image/png'], $schema->extensions);
     }
 
+    public function test_getSchema_exposes_default_values_on_ShapeSchema(): void
+    {
+        $schema = Parser::getSchema(Fixture\ShapeWithOptionalTypes::class);
+        self::assertInstanceOf(ShapeSchema::class, $schema);
+
+        // scalar default
+        self::assertTrue($schema->hasDefaultValue('stringWithDefaultValue'));
+        self::assertSame('default', $schema->defaultValue('stringWithDefaultValue'));
+        self::assertTrue($schema->hasDefaultValue('boolWithDefault'));
+        self::assertFalse($schema->defaultValue('boolWithDefault'));
+
+        // a default of null is distinguishable from "no default"
+        self::assertTrue($schema->hasDefaultValue('optionalInt'));
+        self::assertNull($schema->defaultValue('optionalInt'));
+
+        // required property without a default
+        self::assertFalse($schema->hasDefaultValue('stringBased'));
+    }
+
+    public function test_getSchema_exposes_default_values_as_raw_reflected_values(): void
+    {
+        $schema = Parser::getSchema(Fixture\ShapeWithEnumDefault::class);
+        self::assertInstanceOf(ShapeSchema::class, $schema);
+        self::assertTrue($schema->hasDefaultValue('title'));
+        // the raw enum case is returned, not a normalized/backing representation
+        self::assertSame(Fixture\Title::MR, $schema->defaultValue('title'));
+    }
+
+    public function test_ShapeSchema_defaultValue_throws_for_property_without_default(): void
+    {
+        $schema = Parser::getSchema(Fixture\ShapeWithOptionalTypes::class);
+        self::assertInstanceOf(ShapeSchema::class, $schema);
+        $this->expectException(InvalidArgumentException::class);
+        $schema->defaultValue('stringBased');
+    }
+
     public function test_getSchema_exposes_extensions_on_IntegerSchema(): void
     {
         $schema = Parser::getSchema(Fixture\TimeoutSeconds::class);


### PR DESCRIPTION
## What

`ShapeSchema` now carries the **raw** constructor default values, keyed by property name, and exposes them via two new methods:

- `hasDefaultValue(string $propertyName): bool`
- `defaultValue(string $propertyName): mixed` — throws `InvalidArgumentException` when there is no default

## Why

To let a consumer (e.g. a web form generator) read a property's default straight off the schema and pre-fill the corresponding input field. Previously a constructor like `public string $foo = 'bar'` made the property optional but discarded the default value `'bar'`.

The rest of the form-relevant metadata (constraints, formats, enum cases, optionality, descriptions) is already reachable on the existing schemas, so default values were the one real gap. Rendering forms stays out of this package — it only exposes metadata.

## How

- Defaults are collected in `Parser::getShapeSchema()` whenever `ReflectionParameter::isDefaultValueAvailable()`, mirroring the existing `overriddenPropertyDescriptions` / `propertyDiscriminators` maps.
- **Presence in the map means "has a default"**, so a default of `null` (`?string $foo = null`) is distinguishable from "no default" without a separate flag.
- The value is stored **raw** (scalar / `null` / array / enum case) — lossless and presentation-free; consumers normalize as they see fit.
- The new constructor parameter defaults to `[]`, so the dynamic construction sites (`DynamicSchema::shape`, `ShapeExtender`) are unchanged and dynamic shapes simply carry no defaults.
- `jsonSerialize()` is intentionally **unchanged** — defaults live only on the PHP object.

## Tests / docs

- New `IntegrationTest` cases cover a scalar default, the `null`-vs-absent distinction, a raw enum-case default (proving no normalization), and the throw on a property without a default.
- The `Contact` example in `README.md` documents the new methods; README snippets are executed by `ReadmeCodeBlockTest`, so the docs are verified.
- Full suite (422 tests), PHPStan, and PHP-CS-Fixer all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)